### PR TITLE
Redirection vers le domaine primaire

### DIFF
--- a/.docker/nginx/conf/mon-indemnisation.justice.gouv.dev.conf
+++ b/.docker/nginx/conf/mon-indemnisation.justice.gouv.dev.conf
@@ -1,0 +1,72 @@
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2  on;
+
+# SSL
+    ssl_certificate /etc/nginx/certs/mon-indemnisation.justice.gouv.dev.pem;
+    ssl_certificate_key /etc/nginx/certs/mon-indemnisation.justice.gouv.dev-key.pem;
+    ssl_trusted_certificate /etc/nginx/certs/rootCA.pem;
+
+    server_name mon-indemnisation.justice.gouv.dev;
+    root /app/public;
+
+    error_log /var/log/nginx/mon-indemnisation.justice.gouv.dev.error.log;
+    access_log /var/log/nginx/mon-indemnisation.justice.gouv.dev.access.log;
+
+    location ~ /preview {
+        try_files $uri @vite;
+    }
+
+    location ~ /screenshots {
+        autoindex on;
+        try_files $uri $uri/ =404;
+    }
+
+    location / {
+        try_files $uri @symfony;
+    }
+
+    location @vite {
+        resolver 127.0.0.11 valid=1s;
+        set $upstream http://vite:5173;
+
+        # Websocket
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_pass $upstream;
+    }
+
+    location @symfony {
+        # Allow performing host detection on request
+        resolver 127.0.0.11 valid=1s;
+        set $upstream symfony:9000;
+        fastcgi_pass $upstream;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
+        fastcgi_busy_buffers_size 64k;
+        include fastcgi_params;
+        fastcgi_param APP_ENV dev;
+        fastcgi_param REQUEST_URI $uri;
+        fastcgi_param SCRIPT_FILENAME /app/public/index.php;
+        fastcgi_param DOCUMENT_ROOT /app/public;
+    }
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name mon-indemnisation.justice.gouv.dev;
+
+    location / {
+        return 301 https://mon-indemnisation.justice.gouv.dev/$request_uri;
+    }
+}

--- a/.docker/nginx/conf/mon-indemnisation.justice.gouv.test.conf
+++ b/.docker/nginx/conf/mon-indemnisation.justice.gouv.test.conf
@@ -4,15 +4,15 @@ server {
     http2  on;
 
 # SSL
-    ssl_certificate /etc/nginx/certs/mon-indemnisation.anje-justice.test.pem;
-    ssl_certificate_key /etc/nginx/certs/mon-indemnisation.anje-justice.test-key.pem;
+    ssl_certificate /etc/nginx/certs/mon-indemnisation.justice.gouv.test.pem;
+    ssl_certificate_key /etc/nginx/certs/mon-indemnisation.justice.gouv.test-key.pem;
     ssl_trusted_certificate /etc/nginx/certs/rootCA.pem;
 
-    server_name mon-indemnisation.anje-justice.test;
+    server_name mon-indemnisation.justice.gouv.test;
     root /app/public;
 
-    error_log /var/log/nginx/mon-indemnisation.anje-justice.test.error.log;
-    access_log /var/log/nginx/mon-indemnisation.anje-justice.test.access.log;
+    error_log /var/log/nginx/mon-indemnisation.justice.gouv.test.error.log;
+    access_log /var/log/nginx/mon-indemnisation.justice.gouv.test.access.log;
 
     location / {
         try_files $uri @symfony;
@@ -40,9 +40,9 @@ server {
     listen 80;
     listen [::]:80;
 
-    server_name mon-indemnisation.anje-justice.test;
+    server_name mon-indemnisation.justice.gouv.test;
 
     location / {
-        return 301 https://mon-indemnisation.anje-justice.test/$request_uri;
+        return 301 https://mon-indemnisation.justice.gouv.test/$request_uri;
     }
 }

--- a/.docker/nginx/conf/proconnect.gouv.test.conf
+++ b/.docker/nginx/conf/proconnect.gouv.test.conf
@@ -4,11 +4,11 @@ server {
     http2  on;
 
 # SSL
-    ssl_certificate /etc/nginx/certs/proconnect.anje-justice.test.pem;
-    ssl_certificate_key /etc/nginx/certs/proconnect.anje-justice.test-key.pem;
+    ssl_certificate /etc/nginx/certs/proconnect.gouv.test.pem;
+    ssl_certificate_key /etc/nginx/certs/proconnect.gouv.test-key.pem;
     ssl_trusted_certificate /etc/nginx/certs/rootCA.pem;
 
-    server_name proconnect.anje-justice.test;
+    server_name proconnect.gouv.test;
 
     location / {
         # Allow performing host detection on request
@@ -32,9 +32,9 @@ server {
     listen 80;
     listen [::]:80;
 
-    server_name proconnect.anje-justice.test;
+    server_name proconnect.gouv.test;
 
     location / {
-        return 301 https://proconnect.anje-justice.test/$request_uri;
+        return 301 https://proconnect.gouv.test/$request_uri;
     }
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -31,7 +31,7 @@ services:
         aliases:
           - mon-indemnisation.anje-justice.dev
           - mon-indemnisation.anje-justice.test
-          - proconnect.anje-justice.test
+          - proconnect.gouv.test
     ports:
       - "80:80"
       - "443:443"

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -14,6 +14,7 @@ framework:
         cookie_samesite: lax
         storage_factory_id: session.storage.factory.native
         cookie_lifetime: 1209600 # 14 jours
+        gc_maxlifetime: 1209600
 
     #esi: true
     #fragments: true

--- a/config/packages/routing.yaml
+++ b/config/packages/routing.yaml
@@ -1,7 +1,5 @@
 framework:
     router:
-        # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
-        # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
         default_uri: '%env(BASE_URL)%'
 
 when@prod:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -39,7 +39,6 @@ security:
                 path: agent_securite_deconnexion
                 target: /
         requerant:
-            pattern: ^/requerant
             user_checker: MonIndemnisationJustice\Security\RequerantChecker
             lazy: true
             provider: app_requerant_provider
@@ -58,8 +57,8 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
-      - { path: ^/agent/!(connexion), roles: ROLE_AGENT }
-      - { path: ^/(requerant|sinistre), roles: ROLE_REQUERANT }
+      - { path: ^/requerant/, roles: ROLE_REQUERANT }
+      - { path: ^/agent/, roles: ROLE_AGENT }
 
 when@test:
     security:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -39,6 +39,7 @@ security:
                 path: agent_securite_deconnexion
                 target: /
         requerant:
+            pattern: ^/requerant
             user_checker: MonIndemnisationJustice\Security\RequerantChecker
             lazy: true
             provider: app_requerant_provider

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -37,15 +37,16 @@ services:
         $loginSuccessRoute: 'agent_index'
         $autoPromotionHashes: '%env(default::json:MIJ_AUTO_PROMOTION_HASHES)%'
 
-    MonIndemnisationJustice\Controller\SecurityController:
-        $baseUrl: '%env(BASE_URL)%'
-
     MonIndemnisationJustice\Service\Mailer:
         $emailFrom: '%env(EMAIL_FROM)%'
         $emailFromLabel: '%env(EMAIL_FROM_LABEL)%'
 
     MonIndemnisationJustice\Service\BrisPorteManager:
         $courrielEquipe: '%env(PRECONTENTIEUX_COURRIEL_EQUIPE)%'
+
+    MonIndemnisationJustice\Event\DomaineRedirecteurListener:
+      arguments:
+        $domainePrimaire: '%env(default::MIJ_DOMAINE_PRIMAIRE)%'
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous

--- a/docs/001-Installation.md
+++ b/docs/001-Installation.md
@@ -22,7 +22,7 @@ sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keyc
 # Convertir le certificat racine au format .crt
 openssl x509 -inform PEM -in "$(pwd)/rootCA.pem" -out rootCA.crt
 
-for domain in mon-indemnisation.anje-justice.dev mon-indemnisation.anje-justice.test proconnect.anje-justice.test; do
+for domain in mon-indemnisation.anje-justice.dev mon-indemnisation.justice.gouv.dev mon-indemnisation.justice.gouv.test proconnect.gouv.test; do
   # Génération
   CAROOT=$(pwd) mkcert "${domain}"
   # Register domain as local domain

--- a/src/Controller/Agent/GestionAgentsController.php
+++ b/src/Controller/Agent/GestionAgentsController.php
@@ -79,6 +79,7 @@ class GestionAgentsController extends AbstractController
                 ->setValide()
                 ->setAdministration($administration)
                 ->setRoles($roles);
+
             $this->agentRepository->save($agent);
         }
 

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -31,7 +31,6 @@ class SecurityController extends AbstractController
         protected Mailer $mailer,
         protected EntityManagerInterface $em,
         protected readonly RequerantRepository $requerantRepository,
-        protected readonly string $baseUrl,
         protected readonly OidcClient $oidcClient,
     ) {
     }

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -40,7 +40,6 @@ class SecurityController extends AbstractController
     {
         $error = $this->authenticationUtils->getLastAuthenticationError();
         $lastUsername = $request->query->get('courriel') ?? $this->authenticationUtils->getLastUsername();
-        $user = $this->getUser();
 
         $errorMessage = '';
         if ($error && $error->getMessage()) {
@@ -51,11 +50,7 @@ class SecurityController extends AbstractController
             return $this->redirectToRoute('agent_index');
         }
 
-        if ($request->isMethod(Request::METHOD_POST)) {
-            return $this->redirect($this->oidcClient->buildAuthorizeUrl($request));
-        }
-
-        if (null !== $user) {
+        if ($this->getUser() instanceof Requerant) {
             return $this->redirectToRoute('requerant_home_index');
         }
 
@@ -72,7 +67,7 @@ class SecurityController extends AbstractController
             return $this->redirectToRoute('agent_index');
         }
 
-        if ($this->isCsrfTokenValid('connexionAgent', $request->getPayload()->get('_csrf_token'))) {
+        if ($this->isCsrfTokenValid('connexionAgent', $request->getPayload()->get('_csrf_token_agent'))) {
             return $this->redirect($this->oidcClient->buildAuthorizeUrl($request));
         }
 
@@ -83,9 +78,9 @@ class SecurityController extends AbstractController
     }
 
     #[Route(path: '/deconnexion', name: 'app_logout')]
-    public function logout(): void
+    public function logout(): Response
     {
-        throw new \LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');
+        return $this->redirectToRoute('requerant_home_index');
     }
 
     #[Route(path: '/mon-mot-de-passe/oublie', name: 'app_send_reset_password', methods: ['POST'])]

--- a/src/Entity/Agent.php
+++ b/src/Entity/Agent.php
@@ -7,7 +7,6 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use MonIndemnisationJustice\Repository\AgentRepository;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
-use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 #[ORM\Entity(repositoryClass: AgentRepository::class)]
@@ -15,7 +14,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 #[ORM\UniqueConstraint(name: 'uniq_agent_identifiant', fields: ['identifiant'])]
 #[ORM\HasLifecycleCallbacks]
 #[UniqueEntity(fields: ['identifiant'], message: 'Cet identifiant correspond à un autre agent')]
-class Agent implements UserInterface, PasswordAuthenticatedUserInterface
+class Agent implements UserInterface
 {
     // Le role ROLE_AGENT est donné à chaque agent de la fonction publique
     public const ROLE_AGENT = 'ROLE_AGENT';

--- a/src/Event/DetectObsoleteBrowserListener.php
+++ b/src/Event/DetectObsoleteBrowserListener.php
@@ -17,7 +17,6 @@ use Twig\Environment;
  * La version du navigateur doit être supérieure ou égale aux versions:
  * - supportées par le DSFR https://www.systeme-de-design.gouv.fr/a-propos/configuration-minimale-requise-pour-utiliser-le-dsfr/
  * - prenant en charge les ESM https://caniuse.com/?search=ESM
- *
  */
 class DetectObsoleteBrowserListener implements EventSubscriberInterface
 {

--- a/src/Event/DetectObsoleteBrowserListener.php
+++ b/src/Event/DetectObsoleteBrowserListener.php
@@ -29,7 +29,7 @@ class DetectObsoleteBrowserListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::REQUEST => ['onKernelRequest', 16],
+            KernelEvents::REQUEST => ['onKernelRequest', 1],
         ];
     }
 

--- a/src/Event/DomaineRedirecteurListener.php
+++ b/src/Event/DomaineRedirecteurListener.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace MonIndemnisationJustice\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class DomaineRedirecteurListener implements EventSubscriberInterface
+{
+    public function __construct(
+        protected readonly ?string $domainePrimaire = null,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 32],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (null !== $this->domainePrimaire) {
+            if ($event->getRequest()->getHost() !== $this->domainePrimaire) {
+                $event->setResponse(new RedirectResponse(str_replace($event->getRequest()->getHost(), $this->domainePrimaire, $event->getRequest()->getUri())));
+            }
+        }
+    }
+}

--- a/src/Event/DomaineRedirecteurListener.php
+++ b/src/Event/DomaineRedirecteurListener.php
@@ -17,7 +17,7 @@ final class DomaineRedirecteurListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::REQUEST => ['onKernelRequest', 32],
+            KernelEvents::REQUEST => ['onKernelRequest', 2],
         ];
     }
 

--- a/src/Security/Provider/AgentProvider.php
+++ b/src/Security/Provider/AgentProvider.php
@@ -22,7 +22,7 @@ class AgentProvider implements UserProviderInterface
             throw new UserNotFoundException($user->getUserIdentifier());
         }
 
-        return $user;
+        return $agent;
     }
 
     public function supportsClass(string $class): bool

--- a/templates/agent/redacteur/consulter_bris_porte.html.twig
+++ b/templates/agent/redacteur/consulter_bris_porte.html.twig
@@ -164,7 +164,7 @@
                                         <b>Prénom(s): </b> {{ dossier.requerant.personnePhysique.prenoms }}
                                     </li>
                                     <li>
-                                        <b>Né{% if dossier.requerant.personnePhysique.civilite.estFeminin %}e{% endif %}: </b> le {{ dossier.requerant.personnePhysique.dateNaissance|format_date(locale='fr',pattern="d MMMM YYYY") }}, à {{ dossier.requerant.personnePhysique.communeNaissance}}{% if dossier.requerant.personnePhysique.paysNaissance is not empty %} , {{ dossier.requerant.personnePhysique.paysNaissance }}{% endif %}
+                                        <b>Né{% if dossier.requerant.personnePhysique.civilite.estFeminin %}e{% endif %}: </b> le {{ dossier.requerant.personnePhysique.dateNaissance|format_date(locale='fr',pattern="d MMMM YYYY") }}, à {{ dossier.requerant.personnePhysique.communeNaissance}}{% if dossier.requerant.personnePhysique.paysNaissance is not empty %} , {{ dossier.requerant.personnePhysique.paysNaissance.nom }}{% endif %}
                                     </li>
                                     {% if dossier.requerant.isPersonneMorale %}
                                         <li>
@@ -210,16 +210,16 @@
                                                 tabindex="{{ loop.first ? 0 : -1 }}"
                                                 role="tab"
                                                 aria-selected="{{ loop.first ? 'true' : 'false' }}"
-                                                {% if dossier.documents(type)|length > 0 %}aria-controls="tab-document-{{ type|to_kebab }}-panel" {% else %}disabled{% endif %}
+                                                {% if dossier.documentsParType(type)|length > 0 %}aria-controls="tab-document-{{ type|to_kebab }}-panel" {% else %}disabled{% endif %}
                                             >
-                                                {{ libelle }} {% if dossier.documents(type)|length > 0 %}({{ dossier.documents(type)|length }}){% endif %}
+                                                {{ libelle }} {% if dossier.documentsParType(type)|length > 0 %}({{ dossier.documentsParType(type)|length }}){% endif %}
                                             </button>
                                         </li>
                                     {% endfor %}
                                 </ul>
 
                                 {% for type, libelle in types_document() %}
-                                    {% if dossier.documents(type)|length > 0 %}
+                                    {% if dossier.documentsParType(type)|length > 0 %}
                                         <div
                                             id="tab-document-{{ type|to_kebab }}-panel"
                                             class="fr-tabs__panel{% if loop.first %} fr-tabs__panel--selected{% endif %}"
@@ -227,7 +227,7 @@
                                             aria-labelledby="tab-document-{{ type|to_kebab }}"
                                             tabindex="0"
                                         >
-                                            {% for document in dossier.documents(type) %}
+                                            {% for document in dossier.documentsParType(type) %}
                                                 <div class="fr-grid-row">
                                                     <h6>{{ document.originalFilename }}</h6>
                                                     {% if document.mime == 'application/pdf' %}

--- a/templates/security/connexion.html.twig
+++ b/templates/security/connexion.html.twig
@@ -279,7 +279,7 @@
 
 
                         <form method="post" action="{{ absolute_url(path('securite_connexion_agent')) }}">
-                            <input type="hidden" name="_csrf_token" value="{{ csrf_token('connexionAgent') }}">
+                            <input type="hidden" name="_csrf_token_agent" value="{{ csrf_token('connexionAgent') }}">
                             <div class="fr-connect-group">
                                 <button class="fr-connect" type="submit">
                                     <span class="fr-connect__login">S’identifier avec</span>

--- a/templates/security/connexion.html.twig
+++ b/templates/security/connexion.html.twig
@@ -271,9 +271,8 @@
             <section class="fr-py-2w fr-px-4w">
                 <div class="fr-column fr-column--start">
                     <p>
-                        Je suis <span class="fr-text--bold">un agent du Ministère</span> et je viens instruire les
-                        dossiers
-                        de demande d'indemnisation.
+                        Je suis <span class="fr-text--bold">un agent du Ministère de la Justice</span> et je viens
+                        instruire les dossiers de demande d'indemnisation.
                     </p>
 
                     <div class="fr-grow fr-column fr-column--centered">


### PR DESCRIPTION
# Redirection vers le domaine primaire

Si une requête entrante réclame un nom de domaine différent de `MIJ_DOMAINE_PRIMAIRE`, variable d'env qui peut-être omise, alors la redirigée vers le bon nom de domaine avec les mêmes path et query parameters.

Ceci afin que le nom de domaine en justice.gouv.fr prenne le pas sur le précédent en anje-justice.fr