### PR TITLE
Ajout d'un lien externe vers un tableau de bord public sur Metabase

### DIFF
--- a/templates/_footer.html.twig
+++ b/templates/_footer.html.twig
@@ -36,6 +36,9 @@
                 <li class="fr-footer__bottom-item">
                     <button class="fr-footer__bottom-link fr-icon-theme-fill fr-btn--icon-left" aria-controls="fr-theme-modal" data-fr-opened="false">Paramètres d'affichage</button>
                 </li>
+                <li class="fr-footer__bottom-item">
+                    <a class="fr-footer__bottom-link" href="https://metabase.mon-indemnisation.anje-justice.fr/public/dashboard/fee3713d-0a50-4b3c-8dd5-1ecea851e1a2" target="_blank">Statistiques</a>
+                </li>
             </ul>
             <div class="fr-footer__bottom-copy"><p>Sauf mention explicite de propriété intellectuelle détenue par des
                     tiers, les contenus de ce site sont proposés sous <a


### PR DESCRIPTION
# Ajout d'un lien externe vers un tableau de bord public sur Metabase

Afin de publier la page statistiques, on ajoute un lien vers un tableau de bord public sur notre instance Metabase