### PR TITLE
[ SENTRY ] Le téléversement de document échoue à cause d'un type MIME trop long

### DIFF
--- a/assets/apps/requerant/dossier/components/Uploader.tsx
+++ b/assets/apps/requerant/dossier/components/Uploader.tsx
@@ -13,33 +13,42 @@ export const Uploader = ({
   type: string;
 }) => {
   const MAX_SIZE = 2048 * 1000 * 8;
-  const [erreur, setErreur] = useState("");
+  const [erreur, setErreur]: [string | null, (erreur: string | null) => void] =
+    useState(null);
 
   const id = useRef(randomId());
 
   const handleFileInput = (ev) => {
     setErreur("");
-    const file = ev.target.files[0];
-    if (file.size > MAX_SIZE) {
+    const file: File = ev.target.files[0];
+    if (
+      ![
+        "image/jpeg",
+        "image/png",
+        "image/gif",
+        "image/webp",
+        "application/pdf",
+      ].includes(file.type)
+    ) {
+      setErreur("Type de fichier nom accepté");
+    } else if (file.size > MAX_SIZE) {
       setErreur("Taille de fichier supérieure à 2Mo");
       return;
+    } else {
+      const data = new FormData();
+      data.append("file", ev.target.files[0]);
+      fetch(`/requerant/document/${dossier.id}/${type}`, {
+        method: "POST",
+        body: data,
+      })
+        .then((response) => response.json())
+        .then((document) => onUploaded(document))
+        .catch(() => {});
     }
-
-    const data = new FormData();
-    data.append("file", ev.target.files[0]);
-    fetch(`/requerant/document/${dossier.id}/${type}`, {
-      method: "POST",
-      body: data,
-    })
-      .then((response) => response.json())
-      .then((document) => onUploaded(document))
-      .catch(() => {});
   };
 
   return (
-    <div
-      className={`fr-my-2w fr-upload-group ${erreur ? "fr-input-group--error" : ""}`}
-    >
+    <div className="fr-my-2w fr-upload-group">
       <label className="fr-label" htmlFor={id}>
         {/*<span className="fr-icon-upload-2-line fr-mr-1w" aria-hidden="true"></span>*/}
         {libelle}

--- a/migrations/Version20250422115329.php
+++ b/migrations/Version20250422115329.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250422115329 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE document ALTER mime TYPE VARCHAR(255)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE document ALTER mime TYPE VARCHAR(64)');
+    }
+}

--- a/src/Entity/Document.php
+++ b/src/Entity/Document.php
@@ -57,7 +57,7 @@ class Document
     private ?string $type = null;
 
     #[Groups(['dossier:lecture', 'agent:detail', 'requerant:detail'])]
-    #[ORM\Column(length: 64, nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?string $mime = null;
 
     #[Groups(['dossier:lecture'])]


### PR DESCRIPTION
# [ SENTRY ] Le téléversement de document échoue à cause d'un type MIME trop long

cf. [cette erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/168752/): quand un requérant téléverse un document dont la longueur du type MIME excède 40 caractères, celui-ci échoue.

On ne devrait pas recevoir de document autre que des images ou PDF. Malgré tout, si on se fie à [cette liste des types MIME](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types) connus, la limite des 40 caractères est effectivement arbitraire.