### PR TITLE
Correctifs ajout de PJ agent

### DIFF
--- a/assets/apps/agent/dossiers/components/ConsultationDossierApp.tsx
+++ b/assets/apps/agent/dossiers/components/ConsultationDossierApp.tsx
@@ -173,9 +173,8 @@ export const ConsultationDossierApp = observer(
                 </p>
 
                 {/* Attribution du rédacteur */}
-                {agent.estAttributeur() && dossier.estAAttribuer() && (
-                  <AttributionDossier dossier={dossier} agent={agent} />
-                )}
+
+                <AttributionDossier dossier={dossier} agent={agent} />
 
                 {/* Clôture du dossier */}
                 {dossier.estCloturable() &&
@@ -233,33 +232,32 @@ export const ConsultationDossierApp = observer(
                   >
                     <li role="presentation">
                       <a
-                        href="#infos"
                         id="tab-infos"
                         className="fr-tabs__tab"
                         tabIndex={0}
                         role="tab"
                         aria-selected={window.location.hash == "#infos"}
                         aria-controls="tab-panel-infos"
+                        onClick={() => history.replaceState({}, "", "#infos")}
                       >
                         Informations du dossier
                       </a>
                     </li>
                     <li role="presentation">
                       <a
-                        href="#suivi"
                         id="tab-suivi"
                         className="fr-tabs__tab"
                         tabIndex={-1}
                         role="tab"
                         aria-selected={window.location.hash == "#suivi"}
                         aria-controls="tab-panel-suivi"
+                        onClick={() => history.replaceState({}, "", "#suivi")}
                       >
                         Notes de suivi
                       </a>
                     </li>
                     <li role="presentation">
                       <a
-                        href="#pieces-jointes"
                         id="tab-pieces-jointes"
                         className="fr-tabs__tab"
                         tabIndex={-1}
@@ -268,6 +266,9 @@ export const ConsultationDossierApp = observer(
                           window.location.hash == "#pieces-jointes"
                         }
                         aria-controls="tab-panel-pieces-jointes"
+                        onClick={() =>
+                          history.replaceState({}, "", "#pieces-jointes")
+                        }
                       >
                         Pièces jointes
                       </a>
@@ -556,7 +557,17 @@ export const ConsultationDossierApp = observer(
                               <button
                                 className="fr-btn fr-btn--sm fr-btn--primary"
                                 type="button"
-                                disabled={!dossier.enInstruction()}
+                                disabled={
+                                  !(
+                                    agent.estAttributeur() ||
+                                    agent.estValidateur() ||
+                                    agent.instruit(dossier)
+                                  ) ||
+                                  !(
+                                    dossier.enAttenteDecision ||
+                                    dossier.enAttenteValidation
+                                  )
+                                }
                                 onClick={() => ouvrirModalePieceJointe()}
                               >
                                 Ajouter une pièce jointe
@@ -660,7 +671,7 @@ export const ConsultationDossierApp = observer(
                                             type="file"
                                             id="file-upload"
                                             name="file-upload"
-                                            accept="application/pdf"
+                                            accept="application/pdf,image/*"
                                             onChange={(e) =>
                                               setNouvellePieceJointe(
                                                 e.target.files[0],

--- a/assets/apps/agent/dossiers/components/RechercheDossierApp.tsx
+++ b/assets/apps/agent/dossiers/components/RechercheDossierApp.tsx
@@ -171,9 +171,15 @@ export const RechercheDossierApp = observer(
             </section>
 
             <div className="fr-grid-row">
+              <div className="fr-col-12 fr-my-2w">
+                <h6 className="fr-m-0">
+                  {dossiers.length} dossier{dossiers.length > 1 && "s"} trouvé
+                  {dossiers.length > 1 && "s"}
+                </h6>
+              </div>
               <div className="fr-col-12">
                 <div
-                  className="fr-table"
+                  className="fr-table fr-m-0"
                   id="prec-tableau-dossiers-nouveauxs_container"
                 >
                   <div className="fr-table__wrapper">

--- a/assets/apps/agent/dossiers/components/consultation/AttributionDossier.tsx
+++ b/assets/apps/agent/dossiers/components/consultation/AttributionDossier.tsx
@@ -150,18 +150,20 @@ export const AttributionDossier = observer(
                 </>
               )}
             </p>
-            <ul className="fr-btns-group fr-btns-group--sm fr-btns-group--inline fr-btns-group--right fr-mt-3w">
-              <li>
-                <button
-                  className="fr-btn fr-btn--sm"
-                  type="button"
-                  disabled={sauvegarderEnCours}
-                  onClick={() => setAttributionEnCours(true)}
-                >
-                  Attribuer
-                </button>
-              </li>
-            </ul>
+            {agent.estAttributeur() && dossier.estAAttribuer() && (
+              <ul className="fr-btns-group fr-btns-group--sm fr-btns-group--inline fr-btns-group--right fr-mt-3w">
+                <li>
+                  <button
+                    className="fr-btn fr-btn--sm"
+                    type="button"
+                    disabled={sauvegarderEnCours}
+                    onClick={() => setAttributionEnCours(true)}
+                  >
+                    Attribuer
+                  </button>
+                </li>
+              </ul>
+            )}
           </>
         )}
       </div>

--- a/src/Controller/Agent/DossierController.php
+++ b/src/Controller/Agent/DossierController.php
@@ -115,8 +115,9 @@ class DossierController extends AgentController
         return new JsonResponse('', Response::HTTP_NO_CONTENT);
     }
 
+    // TODO créer un voter https://symfony.com/doc/current/security/voters.html
     #[IsGranted(
-        attribute: new Expression('is_granted("ROLE_AGENT_ATTRIBUTEUR") or user.instruit(subject["dossier"])'),
+        attribute: new Expression('is_granted("ROLE_AGENT_ATTRIBUTEUR") or is_granted("ROLE_AGENT_VALIDATEUR") or user.instruit(subject["dossier"])'),
         subject: [
             'dossier' => new Expression('args["dossier"]'),
         ]
@@ -144,7 +145,13 @@ class DossierController extends AgentController
         ], Response::HTTP_OK);
     }
 
-    #[IsGranted(Agent::ROLE_AGENT_REDACTEUR)]
+    // TODO créer un voter https://symfony.com/doc/current/security/voters.html
+    #[IsGranted(
+        attribute: new Expression('is_granted("ROLE_AGENT_ATTRIBUTEUR") or is_granted("ROLE_AGENT_VALIDATEUR") or user.instruit(subject["dossier"])'),
+        subject: [
+            'dossier' => new Expression('args["dossier"]'),
+        ]
+    )]
     #[Route('/dossier/{id}/piece-jointe/ajouter.json', name: 'agent_redacteur_ajouter_piece_jointe_dossier', methods: ['POST'])]
     public function ajouterPieceJointe(#[MapEntity(id: 'id')] BrisPorte $dossier, Request $request): Response
     {


### PR DESCRIPTION
# Correctifs ajout de PJ agent

Soient les tâches suivantes:
- [x] Autoriser les fichiers images
- [x] Aligner les permissions entre frontend et backend
- [x] Empêcher le retour page arrière d'afficher la modale d'ajout de pièce jointe
- [x] Afficher le nombre de dossiers résultats de la recherche