### PR TITLE
Corriger le champs porte blindée qui ne marche pas

### DIFF
--- a/assets/apps/requerant/dossier/components/BrisPorte.tsx
+++ b/assets/apps/requerant/dossier/components/BrisPorte.tsx
@@ -15,7 +15,6 @@ const BrisPorte = () => {
   return (
     <div className="fr-grid-row fr-grid-row--gutters fr-mb-4w">
       <div className="fr-col-12">
-        <a name="bris-de-porte"></a>
         <section className="pr-form-section fr-p-4w">
           <h3>Informations sur le bris de porte</h3>
           <div className="fr-grid-row fr-grid-row--gutters">
@@ -92,15 +91,15 @@ const BrisPorte = () => {
                   {
                     label: "Oui",
                     nativeInputProps: {
-                      checked: dossier.isPorteBlindee === true,
-                      onChange: () => patchDossier({ isPorteBlindee: true }),
+                      checked: dossier.estPorteBlindee,
+                      onChange: () => patchDossier({ estPorteBlindee: true }),
                     },
                   },
                   {
                     label: "Non",
                     nativeInputProps: {
-                      checked: dossier.isPorteBlindee !== true,
-                      onChange: () => patchDossier({ isPorteBlindee: false }),
+                      checked: !dossier.estPorteBlindee,
+                      onChange: () => patchDossier({ estPorteBlindee: false }),
                     },
                   },
                 ]}

--- a/assets/apps/requerant/dossier/components/BrisPortePanel.tsx
+++ b/assets/apps/requerant/dossier/components/BrisPortePanel.tsx
@@ -53,7 +53,7 @@ const BrisPortePanel = function () {
 
   return (
     <>
-      <section tabIndex="0" className="pr-case_stepper" id="pr-case_stepper">
+      <section tabIndex={0} className="pr-case_stepper" id="pr-case_stepper">
         <Stepper
           currentStep={getCurrentStep()}
           nextTitle={nextTitle}
@@ -99,7 +99,6 @@ const BrisPortePanel = function () {
       )}
       {step === 2 && (
         <>
-          <a name="pieces"></a>
           <div className="fr-grid-row fr-grid-row--gutters fr-mb-4w">
             <div className="fr-col-12">
               <section className="pr-form-section">


### PR DESCRIPTION
# Corriger le champs porte blindée qui ne marche pas

Quand le requérant essaie de changer la valeur de la question "S'agit-il d'une porte blindée ?", rien ne se produit.