### PR TITLE
Empêcher le doublon de dossier initié

### DIFF
--- a/assets/tests/e2e/depot-dossier.e2e.test.ts
+++ b/assets/tests/e2e/depot-dossier.e2e.test.ts
@@ -139,7 +139,7 @@ test("dépôt de dossier", async ({ page }) => {
   await expect(page.getByText("Je déclare mon bris de porte")).toBeEnabled();
   await page.getByText("Je déclare mon bris de porte").click();
 
-  await expect(page).toHaveURL("/requerant");
+  await expect(page).toHaveURL("/requerant/mes-demandes");
 
   // TODO vérifier que la modale de confirmation est bien affichée
   // TODO vérifier qu'un email est bien reçu (cf. PHP) :

--- a/migrations/Version20250617124042.php
+++ b/migrations/Version20250617124042.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250617124042 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Affiner les règles de cascade delete';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE bris_porte DROP CONSTRAINT FK_BC580EED4DE7DC5C');
+        $this->addSql('ALTER TABLE bris_porte DROP CONSTRAINT FK_BC580EEDF90DA413');
+        $this->addSql('ALTER TABLE bris_porte DROP CONSTRAINT FK_BC580EED9450CE1E');
+        $this->addSql('ALTER TABLE bris_porte ADD CONSTRAINT FK_BC580EED4DE7DC5C FOREIGN KEY (adresse_id) REFERENCES adresse (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE bris_porte ADD CONSTRAINT FK_BC580EEDF90DA413 FOREIGN KEY (etat_actuel_id) REFERENCES dossier_etats (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE bris_porte ADD CONSTRAINT FK_BC580EED9450CE1E FOREIGN KEY (test_eligibilite_id) REFERENCES eligibilite_tests (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE dossier_etats DROP CONSTRAINT FK_71671FCF611C0C56');
+        $this->addSql('ALTER TABLE dossier_etats ADD CONSTRAINT FK_71671FCF611C0C56 FOREIGN KEY (dossier_id) REFERENCES bris_porte (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE dossier_etats DROP CONSTRAINT fk_71671fcf611c0c56');
+        $this->addSql('ALTER TABLE dossier_etats ADD CONSTRAINT fk_71671fcf611c0c56 FOREIGN KEY (dossier_id) REFERENCES bris_porte (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE bris_porte DROP CONSTRAINT fk_bc580eedf90da413');
+        $this->addSql('ALTER TABLE bris_porte DROP CONSTRAINT fk_bc580eed4de7dc5c');
+        $this->addSql('ALTER TABLE bris_porte DROP CONSTRAINT fk_bc580eed9450ce1e');
+        $this->addSql('ALTER TABLE bris_porte ADD CONSTRAINT fk_bc580eedf90da413 FOREIGN KEY (etat_actuel_id) REFERENCES dossier_etats (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE bris_porte ADD CONSTRAINT fk_bc580eed4de7dc5c FOREIGN KEY (adresse_id) REFERENCES adresse (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE bris_porte ADD CONSTRAINT fk_bc580eed9450ce1e FOREIGN KEY (test_eligibilite_id) REFERENCES eligibilite_tests (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+}

--- a/src/Entity/Adresse.php
+++ b/src/Entity/Adresse.php
@@ -40,7 +40,7 @@ class Adresse
     /**
      * @var Collection<int, BrisPorte>
      */
-    #[ORM\OneToMany(targetEntity: BrisPorte::class, mappedBy: 'adresse')]
+    #[ORM\OneToMany(targetEntity: BrisPorte::class, mappedBy: 'adresse', cascade: [])]
     private Collection $brisPortes;
 
     public function __toString()

--- a/src/Entity/BrisPorte.php
+++ b/src/Entity/BrisPorte.php
@@ -39,7 +39,7 @@ class BrisPorte
     public ?int $id = null;
 
     #[Groups(['dossier:lecture', 'dossier:patch', 'agent:detail'])]
-    #[ORM\ManyToOne(targetEntity: Requerant::class, cascade: ['persist'], inversedBy: 'dossiers')]
+    #[ORM\ManyToOne(targetEntity: Requerant::class, cascade: [], inversedBy: 'dossiers')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     protected Requerant $requerant;
 
@@ -52,7 +52,7 @@ class BrisPorte
     protected ?string $notes = null;
 
     #[ORM\OneToOne(targetEntity: EtatDossier::class, inversedBy: null)]
-    #[ORM\JoinColumn(name: 'etat_actuel_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[ORM\JoinColumn(name: 'etat_actuel_id', referencedColumnName: 'id', onDelete: 'SET NULL')]
     protected ?EtatDossier $etatDossier = null;
 
     #[ORM\OneToMany(targetEntity: EtatDossier::class, mappedBy: 'dossier', cascade: ['persist', 'remove'], fetch: 'EAGER')]
@@ -80,7 +80,7 @@ class BrisPorte
 
     #[ORM\JoinTable(name: 'document_dossiers')]
     #[ORM\JoinColumn(name: 'dossier_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
-    #[ORM\ManyToMany(targetEntity: Document::class, inversedBy: 'dossiers', cascade: ['persist'])]
+    #[ORM\ManyToMany(targetEntity: Document::class, inversedBy: 'dossiers', cascade: ['persist', 'remove'])]
     /** @var Collection<Document> */
     protected Collection $documents;
     protected ?array $documentsParType = null;
@@ -106,7 +106,8 @@ class BrisPorte
     protected ?string $numeroPV = null;
 
     #[Groups(['dossier:lecture', 'dossier:patch', 'agent:detail', 'agent:liste', 'requerant:detail'])]
-    #[ORM\ManyToOne(inversedBy: 'brisPortes', cascade: ['persist'])]
+    #[ORM\ManyToOne(cascade: ['persist', 'remove'], inversedBy: 'brisPortes')]
+    #[ORM\JoinColumn(onDelete: 'SET NULL')]
     private ?Adresse $adresse;
 
     #[Groups(['dossier:lecture', 'dossier:patch'])]
@@ -121,7 +122,7 @@ class BrisPorte
 
     #[Groups(['agent:detail', 'requerant:detail'])]
     #[ORM\OneToOne(targetEntity: TestEligibilite::class, cascade: ['persist', 'remove'])]
-    #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
     protected ?TestEligibilite $testEligibilite = null;
 
     #[Groups(['dossier:lecture', 'dossier:patch'])]
@@ -154,12 +155,6 @@ class BrisPorte
     public function onPrePersist(PrePersistEventArgs $args): void
     {
         $this->changerStatut(EtatDossierType::DOSSIER_A_FINALISER, requerant: true);
-    }
-
-    #[ORM\PreRemove]
-    public function onPreRemove(): void
-    {
-        $this->etatDossier = null;
     }
 
     #[ORM\PostLoad]

--- a/src/Entity/EtatDossier.php
+++ b/src/Entity/EtatDossier.php
@@ -29,16 +29,16 @@ class EtatDossier
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE, name: 'date')]
     protected \DateTimeInterface $dateEntree;
 
-    #[ORM\ManyToOne(targetEntity: BrisPorte::class, inversedBy: 'historiqueEtats', cascade: ['detach'])]
-    #[ORM\JoinColumn(nullable: false, name: 'dossier_id', referencedColumnName: 'id')]
+    #[ORM\ManyToOne(targetEntity: BrisPorte::class, inversedBy: 'historiqueEtats')]
+    #[ORM\JoinColumn(name: 'dossier_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     protected ?BrisPorte $dossier;
 
-    #[ORM\ManyToOne(targetEntity: Agent::class, cascade: ['detach'])]
+    #[ORM\ManyToOne(targetEntity: Agent::class, cascade: [])]
     #[ORM\JoinColumn(name: 'agent_id', referencedColumnName: 'id', onDelete: 'SET NULL')]
     protected ?Agent $agent;
 
-    #[ORM\ManyToOne(targetEntity: Requerant::class, cascade: ['detach'])]
-    #[ORM\JoinColumn(name: 'requerant_id', referencedColumnName: 'id', )]
+    #[ORM\ManyToOne(targetEntity: Requerant::class, cascade: [])]
+    #[ORM\JoinColumn(name: 'requerant_id', referencedColumnName: 'id')]
     protected ?Requerant $requerant;
 
     #[Groups(['agent:liste', 'agent:detail', 'requerant:detail'])]

--- a/src/Entity/TestEligibilite.php
+++ b/src/Entity/TestEligibilite.php
@@ -44,7 +44,7 @@ class TestEligibilite
     #[ORM\Column(nullable: true)]
     public ?bool $aContacteBailleur = null;
 
-    #[ORM\OneToOne(targetEntity: Requerant::class, cascade: ['persist', 'remove'])]
+    #[ORM\OneToOne(targetEntity: Requerant::class, cascade: ['persist'])]
     #[ORM\JoinColumn(onDelete: 'CASCADE')]
     public ?Requerant $requerant = null;
 

--- a/templates/brisPorte/tester_mon_eligibilite.html.twig
+++ b/templates/brisPorte/tester_mon_eligibilite.html.twig
@@ -57,6 +57,13 @@
                 <input type="hidden" name="_token" value="{{ form._token.vars.value }}">
                 <input type="hidden" name="estIssuAttestation" value="{{ form.estIssuAttestation.vars.value }}">
 
+                <div class="fr-alert fr-alert--info fr-mb-2w">
+                    <p>
+                        Si vous avez déjà rempli ce questionnaire et créé un compte, <a class="fr-link"
+                                                                                        href="{{ url('app_login') }}">connectez-vous</a>.
+                    </p>
+                </div>
+
                 <div class="fr-callout">
                     <h3 class="fr-callout__title">
                         Avant de remplir le questionnaire
@@ -68,6 +75,7 @@
                            id="lien-infobulle-respect-principe" href="#">le respect de ce principe</a>
                         et vérifier votre éligibilité à l'indemnisation, vous devez répondre aux questions suivantes.
                     </p>
+
                     <span class="fr-tooltip fr-placement" id="infobulle-respect-principe" role="tooltip"
                           aria-hidden="true">
                         En vertu du principe de réparation intégrale du préjudice sans perte ni profit, la victime d'un
@@ -75,6 +83,23 @@
                         cassation, civile, Chambre civile 2, 16 décembre 2021, 19-11.294, Inédit ; Cour de cassation,
                         civile, Chambre civile 2, 9 février 2023, 21-21.217, Publié au bulletin)
                     </span>
+
+                    <p class="fr-callout__text fr-mt-2w">
+                        En cas d'éligibilité, vous serez amené à présenter les documents suivants :
+                    </p>
+
+                    <ul>
+                        <li>Attestation d’information complétée par les forces de l’ordre</li>
+                        <li>Photo de la porte endommagée</li>
+                        <li>Attestation de non prise en charge du sinistre par votre assurance habitation</li>
+                        <li>Attestation de non prise en charge du sinistre par le bailleur</li>
+                        <li>Copie recto-verso de votre pièce d’identité ou un extrait Kbis de moins de 3 mois (si vous
+                            êtes une personne morale)
+                        </li>
+                        <li>La facture acquittée attestant de la réalité des travaux de remise en état à l'identique
+                        </li>
+                        <li>Votre titre de propriété ou votre contrat de bail</li>
+                    </ul>
                 </div>
 
                 {# Questions #}

--- a/templates/requerant/_header.html.twig
+++ b/templates/requerant/_header.html.twig
@@ -29,7 +29,8 @@
                     <div class="fr-header__tools-links">
                         <ul class="fr-btns-group">
                             <li>
-                                <span class="fr-btn fr-icon-user-line">{{ app.user.personnePhysique.prenom1 }} {{ app.user.personnePhysique.nom|capitalize }}</span>
+                                <a class="fr-btn fr-icon-user-line"
+                                   href="{{ url('requerant_home_index') }}">{{ app.user.personnePhysique.prenom1 }} {{ app.user.personnePhysique.nom|capitalize }}</a>
                             </li>
                             <li>
                                 <a class="fr-btn fr-icon-logout-box-r-line"
@@ -73,13 +74,13 @@
                 <nav id="fr-header-main-navigation" class="fr-nav" role="navigation" aria-label="Menu principal">
                     <ul class="fr-nav__list">
                         <li class="fr-nav__item" data-fr-js-navigation-item="true">
-                            <a href="{{ path('app_homepage') }}" class="fr-nav__link">
+                            <a href="{{ path('requerant_home_index') }}" class="fr-nav__link">
                                 <span class="fr-icon-home-4-line fr-text--bold" aria-hidden="true"></span>
                             </a>
                         </li>
 
                         <li class="fr-nav__item" data-fr-js-navigation-item="true">
-                            <a href="{{ url('requerant_home_index') }}" class="fr-nav__link">Mes demandes</a>
+                            <a href="{{ url('requerant_home_dossiers') }}" class="fr-nav__link">Mes demandes</a>
                         </li>
                     </ul>
                 </nav>

--- a/templates/requerant/default/index.html.twig
+++ b/templates/requerant/default/index.html.twig
@@ -51,7 +51,7 @@
                     {# TODO voir si on peut adapter l'affichage en mobile #}
 
                     <table data-fr-js-table-element="true" class="">
-                        <caption>Mes dossiers</caption>
+                        <caption>Mes demandes</caption>
                         <thead>
                         <tr>
                             <th scope="col" class="fr-col-1">Référence</th>

--- a/tests/Controller/Requerant/HomeControllerTest.php
+++ b/tests/Controller/Requerant/HomeControllerTest.php
@@ -2,11 +2,11 @@
 
 namespace MonIndemnisationJustice\Tests\Controller\Requerant;
 
+use Doctrine\ORM\EntityManagerInterface;
 use MonIndemnisationJustice\Entity\Adresse;
 use MonIndemnisationJustice\Entity\Civilite;
 use MonIndemnisationJustice\Entity\PersonnePhysique;
 use MonIndemnisationJustice\Entity\Requerant;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -35,20 +35,19 @@ class HomeControllerTest extends WebTestCase
         $requerant = (new Requerant())
             ->setAdresse(
                 (new Adresse())
-                ->setLigne1('12 rue des Oliviers')
-                ->setLocalite('Nantes')
-                ->setCodePostal('44100')
+                    ->setLigne1('12 rue des Oliviers')
+                    ->setLocalite('Nantes')
+                    ->setCodePostal('44100')
             )
             ->setPersonnePhysique(
                 (new PersonnePhysique())
-                ->setEmail('raquel.randt@courriel.fr')
-                ->setCivilite(Civilite::MME)
-                ->setPrenom1('Raquel')
-                ->setNom('Randt')
+                    ->setEmail('raquel.randt@courriel.fr')
+                    ->setCivilite(Civilite::MME)
+                    ->setPrenom1('Raquel')
+                    ->setNom('Randt')
             )
             ->setEmail('raquel.randt@courriel.fr')
-            ->setRoles([Requerant::ROLE_REQUERANT])
-        ;
+            ->setRoles([Requerant::ROLE_REQUERANT]);
         $requerant->setPassword($this->passwordHasher->hashPassword($requerant, 'P4ssword'));
 
         $this->em->persist($requerant);
@@ -63,6 +62,6 @@ class HomeControllerTest extends WebTestCase
 
         $this->client->request('GET', '/requerant');
 
-        $this->assertResponseIsSuccessful();
+        $this->assertResponseRedirects('/requerant/mes-demandes');
     }
 }


### PR DESCRIPTION
# Empêcher le doublon de dossier initié

ETQ requérant, quand j'initie un dossier, si je me déconnecte et me reconnecte (ex: changement d'appareil) je risque de recréer un nouveau dossier initié si je repasse par la case test d'éligibilité.

Ce qui change ici : 
* redirection automatique vers la page d'accueil de l'espace requérant si sur le test d'éligibilité alors que déjà connecté 
* sinon un bandeau apparaît en haut du test d'éligibilité pour inviter à se connecter pour continuer
* sinon on vérifie que le dernier dossier n'est pas en attente de finalisation avant de recréer un nouveau dossier (le dernier test d'éligibilité, redondant, est purement supprimé)

Au passage on ajoute quelques règles de "cascade delete" pour sécuriser les opérations de suppression. 

Requête SQL pour les détecter:

```sql
select d.id, pp.prenom1||' '||pp.nom as requerant
from bris_porte d
    inner join dossier_etats ed on d.etat_actuel_id = ed.id and ed.etat = 'A_FINALISER'
    inner join requerants r on d.requerant_id = r.id
    inner join personne_physique pp on r.personne_physique_id = pp.id
where exists (
    select *
    from bris_porte d2
        inner join dossier_etats ed2 on ed2.dossier_id = d2.id and ed2.etat = 'A_FINALISER'
    where
        d2.requerant_id = d.requerant_id
        and d2.id <> d.id
        and ed2.date > ed.date
);
```
