### PR TITLE
Réconcilier les données de communes naissance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,10 +117,10 @@ jobs:
         run: yarn build
 
       - name: Run migration
-        run: bin/console doctrine:migrations:migrate --no-interaction --all-or-nothing
+        run: bin/console -e test doctrine:migrations:migrate --no-interaction --all-or-nothing
 
       - name: Load data fixtures
-        run: bin/console -e test -n doctrine:fixture:load --purge-with-truncate --purge-exclusions=geo_departements --purge-exclusions=geo_regions --purge-exclusions=geo_communes --purge-exclusions=geo_codes_postaux
+        run: bin/console -e test -n doctrine:fixture:load --purge-with-truncate
 
       - name: Run backend unit tests
         run: bin/phpunit --log-junit test-result-backend.xml
@@ -296,10 +296,10 @@ jobs:
         run: yarn build
 
       - name: Run migration
-        run: bin/console doctrine:migrations:migrate --no-interaction --all-or-nothing
+        run: bin/console -e test doctrine:migrations:migrate --no-interaction --all-or-nothing
 
       - name: Load data fixtures
-        run: bin/console -e test -n doctrine:fixture:load --purge-with-truncate --purge-exclusions=geo_departements --purge-exclusions=geo_regions --purge-exclusions=geo_communes --purge-exclusions=geo_codes_postaux
+        run: bin/console -e test -n doctrine:fixture:load --purge-with-truncate
 
       - name: Run end-to-end tests
         # Pour l'heure on se limite à Firefox car on ne sait pas encore créer des fixtures par Browser

--- a/assets/apps/requerant/dossier/components/BrisPortePanel.tsx
+++ b/assets/apps/requerant/dossier/components/BrisPortePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Document } from "@/apps/requerant/dossier/components/PieceJointe/PieceJointe.tsx";
@@ -10,6 +10,7 @@ import {
   DossierContext,
   PatchDossierContext,
 } from "@/apps/requerant/dossier/contexts/DossierContext.ts";
+import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 
 const BrisPortePanel = function () {
   const dossier = useContext(DossierContext);
@@ -35,13 +36,16 @@ const BrisPortePanel = function () {
     setStep(step + 1);
     gotoStepper();
   }
+
   function decrementStep() {
     setStep(step - 1);
     gotoStepper();
   }
+
   function getCurrentStep() {
     return step + 1;
   }
+
   function gotoStepper() {
     document.getElementById("pr-case_stepper")?.focus();
   }
@@ -69,13 +73,16 @@ const BrisPortePanel = function () {
       {step === 0 && (
         <section className="pr-case_form fr-mb-4w">
           <User />
-          <div className="fr-grid-row fr-grid-row--gutters">
-            <div className="fr-col-12">
-              <Button onClick={incrementStep}>
-                Valider et passer à l'étape suivante
-              </Button>
-            </div>
-          </div>
+          <ButtonsGroup
+            inlineLayoutWhen="always"
+            alignment="right"
+            buttons={[
+              {
+                children: "Valider et passer à l'étape suivante",
+                onClick: () => incrementStep(),
+              },
+            ]}
+          />
         </section>
       )}
       {step === 1 && (

--- a/assets/apps/requerant/dossier/components/PersonnePhysique.tsx
+++ b/assets/apps/requerant/dossier/components/PersonnePhysique.tsx
@@ -1,4 +1,11 @@
-import React, { useContext } from "react";
+import React, {
+  KeyboardEvent,
+  KeyboardEventHandler,
+  useContext,
+  useDeferredValue,
+  useEffect,
+  useState,
+} from "react";
 import Civilite from "@/apps/requerant/dossier/components/Civilite";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import {
@@ -9,16 +16,46 @@ import { PaysContext } from "@/apps/requerant/dossier/contexts/PaysContext.ts";
 import { randomId } from "@/apps/requerant/dossier/services/Random.ts";
 import { Select } from "@codegouvfr/react-dsfr/Select";
 
-const PersonnePhysique = function () {
+interface GeoCommune {
+  id: number;
+  nom: string;
+}
+
+const PersonnePhysique = function PersonnePhysique() {
   const dossier = useContext(DossierContext);
   const pays = useContext(PaysContext);
   const patchDossier = useContext(PatchDossierContext);
 
+  const [paysNaissance, setPaysNaissance] = useState<string>(
+    dossier.requerant.personnePhysique.paysNaissance ?? null,
+  );
+
+  const [codePostalNaissance, setCodePostalNaissance] = useState(
+    dossier.requerant.personnePhysique.codePostalNaissance || "",
+  );
+
+  const [communes, setCommunes] = useState<GeoCommune[]>([]);
+  useEffect(() => {
+    if (codePostalNaissance.length === 5) {
+      const rafraichirCommunes = async (codePostal: string) => {
+        const response = await fetch(`/api/communes/${codePostal}`);
+
+        const communes = (await response.json()) as GeoCommune[];
+        setCommunes(communes);
+      };
+
+      rafraichirCommunes(codePostalNaissance);
+    }
+
+    setCommunes([]);
+  }, [codePostalNaissance]);
+
   return (
     <>
       <h3>Votre identité</h3>
+
       <div className="fr-grid-row fr-grid-row--gutters">
-        <div className="fr-col-lg-3 fr-col-4">
+        <div className="fr-col-lg-2 fr-col-4">
           <Civilite
             estActif={!dossier.requerant.estFranceConnect}
             civilite={dossier.requerant.personnePhysique?.civilite}
@@ -27,7 +64,7 @@ const PersonnePhysique = function () {
             }
           />
         </div>
-        <div className="fr-col-lg-9 fr-col-8">
+        <div className="fr-col-lg-7 fr-col-8">
           <Input
             disabled={dossier.requerant.estFranceConnect}
             label="Prénom(s)"
@@ -43,7 +80,21 @@ const PersonnePhysique = function () {
             }}
           />
         </div>
-        <div className="fr-col-lg-6 fr-col-12">
+        <div className="fr-col-lg-3 fr-col-6">
+          <Input
+            label="Nom d'usage"
+            nativeInputProps={{
+              id: randomId(),
+              defaultValue: dossier.requerant.personnePhysique.nom || "",
+              onChange: (e) =>
+                patchDossier({
+                  requerant: { personnePhysique: { nom: e.target.value } },
+                }),
+              maxLength: 255,
+            }}
+          />
+        </div>
+        <div className="fr-col-lg-4 fr-col-6">
           <Input
             disabled={dossier.requerant.estFranceConnect}
             label="Nom de naissance"
@@ -60,21 +111,35 @@ const PersonnePhysique = function () {
             }}
           />
         </div>
-        <div className="fr-col-lg-6 fr-col-12">
+        <div className="fr-col-lg-4 fr-col-6">
           <Input
-            label="Nom d'usage"
+            disabled={true}
+            label="Adresse courriel"
             nativeInputProps={{
               id: randomId(),
-              value: dossier.requerant.personnePhysique.nom || "",
-              onChange: (e) =>
-                patchDossier({
-                  requerant: { personnePhysique: { nom: e.target.value } },
-                }),
+              defaultValue: dossier.requerant.courriel,
+              disabled: true,
               maxLength: 255,
             }}
           />
         </div>
-        <div className="fr-col-lg-3 fr-col-12">
+        <div className="fr-col-lg-4 fr-col-6">
+          <Input
+            label="Téléphone"
+            nativeInputProps={{
+              id: randomId(),
+              type: "tel",
+              pattern: "(0,+){1}[0-9]{8,}",
+              defaultValue: dossier.requerant.telephone || "",
+            }}
+          />
+        </div>
+      </div>
+
+      <h3 className="fr-my-2w">Votre naissance</h3>
+
+      <div className="fr-grid-row fr-grid-row--gutters">
+        <div className="fr-col-lg-3 fr-col-6">
           <Input
             disabled={dossier.requerant.estFranceConnect}
             label="Date de naissance"
@@ -85,41 +150,29 @@ const PersonnePhysique = function () {
               onChange: (e) =>
                 patchDossier({
                   requerant: {
-                    personnePhysique: { dateNaissance: e.target.value || null },
+                    personnePhysique: {
+                      dateNaissance: e.target.value || null,
+                    },
                   },
                 }),
             }}
           />
         </div>
-        <div className="fr-col-lg-6 fr-col-12">
-          <Input
-            disabled={dossier.requerant.estFranceConnect}
-            label="Ville de naissance"
-            nativeInputProps={{
-              id: randomId(),
-              value: dossier.requerant.personnePhysique.communeNaissance || "",
-              onChange: (e) =>
-                patchDossier({
-                  requerant: {
-                    personnePhysique: { communeNaissance: e.target.value },
-                  },
-                }),
-              maxLength: 255,
-            }}
-          />
-        </div>
-        <div className="fr-col-lg-3 fr-col-12">
+
+        <div className="fr-col-lg-3 fr-col-6">
           <Select
             disabled={dossier.requerant.estFranceConnect}
             label="Pays de naissance"
             nativeSelectProps={{
               id: randomId(),
-              onChange: (e) =>
+              onChange: (e) => {
+                setPaysNaissance(e.target.value);
                 patchDossier({
                   requerant: {
                     personnePhysique: { paysNaissance: e.target.value },
                   },
-                }),
+                });
+              },
               value: dossier.requerant.personnePhysique.paysNaissance || "",
             }}
           >
@@ -127,12 +180,87 @@ const PersonnePhysique = function () {
               Sélectionnez un pays
             </option>
             {pays.map((p) => (
-              <option key={p.code} value={`/api/geo-pays/${p.code}`}>
+              <option key={p.code} value={`/api/geo_pays/${p.code}`}>
                 {p.nom}
               </option>
             ))}
           </Select>
         </div>
+
+        <div className="fr-col-lg-2 fr-col-4">
+          <Input
+            label="Code postal"
+            disabled={paysNaissance !== "/api/geo_pays/FRA"}
+            nativeInputProps={{
+              id: randomId(),
+              type: "text",
+              maxLength: 5,
+              pattern: "^[0-9]{0,5}$",
+              value: codePostalNaissance,
+              onFocus: (e) => {
+                e.target.setSelectionRange(
+                  e.target.value.length + 1,
+                  e.target.value.length + 1,
+                );
+              },
+              onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
+                if (e.key !== "Backspace") {
+                  const target: HTMLInputElement = e.target as HTMLInputElement;
+
+                  const projectedValue =
+                    target.value.substring(0, target.selectionStart || 0) +
+                    e.key +
+                    target.value.substring(target.selectionEnd || 0);
+
+                  if (!projectedValue.match(new RegExp(target.pattern))) {
+                    e.stopPropagation();
+                    e.preventDefault();
+                  }
+                }
+              },
+              onChange: (e) => setCodePostalNaissance(e.target.value),
+            }}
+          />
+        </div>
+
+        <div className="fr-col-lg-4 fr-col-8">
+          <Select
+            disabled={
+              dossier.requerant.estFranceConnect || communes.length === 0
+            }
+            label="Ville de naissance"
+            nativeSelectProps={{
+              id: randomId(),
+              value: dossier.requerant.personnePhysique.communeNaissance || "",
+              onChange: (e) => {
+                patchDossier({
+                  requerant: {
+                    personnePhysique: {
+                      communeNaissance: e.target.value,
+                    },
+                  },
+                });
+              },
+            }}
+          >
+            <option value={undefined}>
+              {communes.length === 0
+                ? "Tapez le code postal"
+                : "Sélectionnez une ville"}
+            </option>
+            {communes.map((commune) => (
+              <option
+                key={commune.id}
+                value={`/api/geo_code_postals/${commune.id}`}
+              >
+                {commune.nom}
+              </option>
+            ))}
+          </Select>
+        </div>
+      </div>
+
+      {/*
         <div className="fr-col-lg-6 fr-col-12">
           <div className="fr-grid-row fr-grid-row--gutters">
             <div className="fr-col-12">
@@ -157,11 +285,77 @@ const PersonnePhysique = function () {
             </div>
           </div>
         </div>
+        */}
+
+      <h3 className="fr-mt-3w">Votre adresse de résidence</h3>
+
+      <div className="fr-grid-row fr-grid-row--gutters">
+        <div className="fr-col-lg-6 fr-col-12">
+          <Input
+            label="Adresse"
+            nativeInputProps={{
+              value: dossier.requerant.adresse.ligne1 || "",
+              placeholder: "Numéro de voie, rue",
+              onChange: (e) =>
+                patchDossier({
+                  requerant: {
+                    adresse: { ligne1: e.target.value },
+                  },
+                }),
+              maxLength: 255,
+            }}
+          />
+        </div>
+
+        <div className="fr-col-lg-6 fr-col-12">
+          <Input
+            label="Complément d'adresse (facultatif)"
+            nativeInputProps={{
+              value: dossier.requerant.adresse.ligne2 || "",
+              placeholder: "Étage, escalier",
+              onChange: (e) =>
+                patchDossier({
+                  requerant: {
+                    adresse: { ligne2: e.target.value },
+                  },
+                }),
+              maxLength: 255,
+            }}
+          />
+        </div>
+        <div className="fr-col-lg-2 fr-col-4">
+          <Input
+            label="Code postal"
+            nativeInputProps={{
+              value: dossier.requerant.adresse.codePostal || "",
+              onChange: (e) =>
+                patchDossier({
+                  requerant: {
+                    adresse: { codePostal: e.target.value },
+                  },
+                }),
+              maxLength: 5,
+            }}
+          />
+        </div>
+        <div className="fr-col-lg-10 fr-col-8">
+          <Input
+            label="Ville"
+            nativeInputProps={{
+              value: dossier.requerant.adresse.localite || "",
+              onChange: (e) =>
+                patchDossier({
+                  requerant: {
+                    adresse: { localite: e.target.value },
+                  },
+                }),
+              maxLength: 255,
+            }}
+          />
+        </div>
       </div>
     </>
   );
 };
-
-PersonnePhysique.propTypes = {};
 
 export default PersonnePhysique;

--- a/assets/apps/requerant/dossier/components/User.tsx
+++ b/assets/apps/requerant/dossier/components/User.tsx
@@ -17,7 +17,7 @@ const User = function () {
     <>
       <div className="fr-grid-row">
         <div className="fr-col-12">
-          <div className="pr-case_bris-de-porte_is-personne-morale fr-px-2w fr-pt-4w">
+          <div className="pr-case_bris-de-porte_is-personne-morale fr-pt-2w">
             <RadioButtons
               orientation="horizontal"
               legend="Votre demande d'indemnisation concerne une personne morale (société, entreprise, association, fondation etc.)"
@@ -223,76 +223,11 @@ const User = function () {
       )}
       {!dossier.requerant.isPersonneMorale && (
         <>
-          <div id="pr-bris-de-porte_personne-physique">
+          <div id="pr-bris-de-porte_personne-physique" className="fr-mb-4w">
             <div className="fr-grid-row fr-grid-row--gutters">
               <div className="fr-col-12">
-                <section className="pr-form-section fr-p-4w">
+                <section className="pr-form-section">
                   <PersonnePhysique />
-                  <div className="fr-grid-row fr-grid-row--gutters">
-                    <div className="fr-col-lg-6 fr-col-12">
-                      <Input
-                        label="Adresse"
-                        nativeInputProps={{
-                          value: dossier.requerant.adresse.ligne1 || "",
-                          placeholder: "Numéro de voie, rue",
-                          onChange: (e) =>
-                            patchDossier({
-                              requerant: {
-                                adresse: { ligne1: e.target.value },
-                              },
-                            }),
-                          maxLength: 255,
-                        }}
-                      />
-                    </div>
-
-                    <div className="fr-col-lg-6 fr-col-12">
-                      <Input
-                        label="Complément d'adresse (facultatif)"
-                        nativeInputProps={{
-                          value: dossier.requerant.adresse.ligne2 || "",
-                          placeholder: "Étage, escalier",
-                          onChange: (e) =>
-                            patchDossier({
-                              requerant: {
-                                adresse: { ligne2: e.target.value },
-                              },
-                            }),
-                          maxLength: 255,
-                        }}
-                      />
-                    </div>
-                    <div className="fr-col-lg-2 fr-col-4">
-                      <Input
-                        label="Code postal"
-                        nativeInputProps={{
-                          value: dossier.requerant.adresse.codePostal || "",
-                          onChange: (e) =>
-                            patchDossier({
-                              requerant: {
-                                adresse: { codePostal: e.target.value },
-                              },
-                            }),
-                          maxLength: 5,
-                        }}
-                      />
-                    </div>
-                    <div className="fr-col-lg-10 fr-col-8">
-                      <Input
-                        label="Ville"
-                        nativeInputProps={{
-                          value: dossier.requerant.adresse.localite || "",
-                          onChange: (e) =>
-                            patchDossier({
-                              requerant: {
-                                adresse: { localite: e.target.value },
-                              },
-                            }),
-                          maxLength: 255,
-                        }}
-                      />
-                    </div>
-                  </div>
                 </section>
               </div>
             </div>

--- a/assets/apps/requerant/dossier/deposer_mon_dossier.tsx
+++ b/assets/apps/requerant/dossier/deposer_mon_dossier.tsx
@@ -39,8 +39,6 @@ pays.sort((pays1: any, pays2: any) => {
   return pays1.code.localeCompare(pays2.code);
 });
 
-console.log(pays);
-
 // Pré-population des listes de documents par type
 const documents = {
   attestation_information: [],

--- a/assets/tests/e2e/depot-dossier.e2e.test.ts
+++ b/assets/tests/e2e/depot-dossier.e2e.test.ts
@@ -52,11 +52,14 @@ test("dépôt de dossier", async ({ page }) => {
     page.locator("h2", { hasText: "Données personnelles" }),
   ).toBeVisible();
 
+  /*
   await page
     .getByLabel("Les 10 premiers chiffres de votre numéro de sécurité sociale")
     .fill("2790656123");
-  await page.getByLabel("Ville de naissance").fill("Turenne");
+
+   */
   await page.getByLabel("Pays de naissance").selectOption("France");
+  //await page.getByLabel("Ville de naissance").fill("Turenne");
   await page.getByLabel("Date de naissance").fill("1979-05-17");
 
   await expect(

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MonIndemnisationJustice\Controller;
+
+use MonIndemnisationJustice\Entity\GeoCodePostal;
+use MonIndemnisationJustice\Repository\GeoCodePostalRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/api')]
+class ApiController extends AbstractController
+{
+    public function __construct(
+        protected readonly GeoCodePostalRepository $geoCodePostalRepository,
+    ) {
+    }
+
+    #[Route('/communes/{codePostal}', name: 'api_code_postaux', methods: ['GET'])]
+    public function index(string $codePostal): Response
+    {
+        return new JsonResponse(array_map(
+            fn (GeoCodePostal $geoCodePostal) => [
+                'id' => $geoCodePostal->getId(),
+                'nom' => $geoCodePostal->getCommune()->getNom(),
+            ],
+            $this->geoCodePostalRepository->findBy(['codePostal' => $codePostal])
+        ));
+    }
+}

--- a/src/DataFixtures/DossierFixture.php
+++ b/src/DataFixtures/DossierFixture.php
@@ -9,8 +9,11 @@ use MonIndemnisationJustice\Entity\Adresse;
 use MonIndemnisationJustice\Entity\Agent;
 use MonIndemnisationJustice\Entity\BrisPorte;
 use MonIndemnisationJustice\Entity\Civilite;
+use MonIndemnisationJustice\Entity\GeoCodePostal;
+use MonIndemnisationJustice\Entity\GeoCommune;
 use MonIndemnisationJustice\Entity\GeoDepartement;
 use MonIndemnisationJustice\Entity\GeoPays;
+use MonIndemnisationJustice\Entity\GeoRegion;
 use MonIndemnisationJustice\Entity\PersonnePhysique;
 use MonIndemnisationJustice\Entity\Requerant;
 use MonIndemnisationJustice\Entity\TestEligibilite;
@@ -49,6 +52,69 @@ class DossierFixture implements ORMFixtureInterface
 
         $manager->persist($maroc);
 
+        // Région, département, commune et code postal
+        $auvergneRhoneAlpes = (new GeoRegion())
+            ->setCode('84')
+            ->setNom('Auvergne-Rhône-Alpes');
+        $isere = (new GeoDepartement())
+            ->setRegion($auvergneRhoneAlpes)
+            ->setCode('38')
+            ->setNom('Isère')
+            ->setDeploye(true);
+        $bourgoin = (new GeoCommune())
+            ->setCode('38053')
+            ->setNom('Bourgoin-Jallieu')
+            ->setDepartement($isere);
+        $codePostal38300 = (new GeoCodePostal())
+            ->setCommune($bourgoin)
+            ->setCodePostal('38300');
+
+        $manager->persist($codePostal38300);
+
+        $paca = (new GeoRegion())
+            ->setCode('93')
+            ->setNom("Provence-Alpes-Côte d'Azur");
+        $bouchesDuRhone = (new GeoDepartement())
+            ->setRegion($paca)
+            ->setCode('13')
+            ->setNom('Bouches-du-Rhône')
+            ->setDeploye(true);
+
+        $manager->persist($bouchesDuRhone);
+
+        $ileDeFrance = (new GeoRegion())
+            ->setCode('11')
+            ->setNom('Île-de-France');
+        $seineEtMarne = (new GeoDepartement())
+            ->setRegion($ileDeFrance)
+            ->setCode('77')
+            ->setNom('Seine-et-Marne')
+            ->setDeploye(true);
+
+        $manager->persist($seineEtMarne);
+
+        $bretagne = (new GeoRegion())
+            ->setCode('53')
+            ->setNom('Bretagne');
+        $illeEtVillaine = (new GeoDepartement())
+            ->setRegion($bretagne)
+            ->setCode('35')
+            ->setNom('Ille-et-Vilaine')
+            ->setDeploye(true);
+
+        $manager->persist($illeEtVillaine);
+
+        $paysDeLaLoire = (new GeoRegion())
+            ->setCode('52')
+            ->setNom('Pays de la Loire');
+        $loireAtlantique = (new GeoDepartement())
+            ->setRegion($paysDeLaLoire)
+            ->setCode('44')
+            ->setNom('Loire-Atlantique')
+            ->setDeploye(false);
+
+        $manager->persist($loireAtlantique);
+
         // Agents
         $redacteur = (new Agent())
             ->setNom('Acteur')
@@ -64,25 +130,24 @@ class DossierFixture implements ORMFixtureInterface
         $requerant = (new Requerant())
             ->setAdresse(
                 (new Adresse())
-                ->setLigne1('12 rue des Oliviers')
-                ->setLocalite('Nantes')
-                ->setCodePostal('44100')
+                    ->setLigne1('12 rue des Oliviers')
+                    ->setLocalite('Nantes')
+                    ->setCodePostal('44100')
             )
             ->setPersonnePhysique(
                 (new PersonnePhysique())
-                ->setCivilite(Civilite::MME)
-                ->setPrenom1('Raquel')
-                ->setNom('Randt')
-                ->setDateNaissance(new \DateTime('1979-05-17'))
-            ->setCommuneNaissance('Bourgoin')
-            ->setPaysNaissance($manager->find(GeoPays::class, 'FRA'))
-            ->setNumeroSecuriteSociale('')
-            ->setTelephone('0621436587')
+                    ->setCivilite(Civilite::MME)
+                    ->setPrenom1('Raquel')
+                    ->setNom('Randt')
+                    ->setDateNaissance(new \DateTime('1979-05-17'))
+                    ->setCommuneNaissance($codePostal38300)
+                    ->setPaysNaissance($france)
+                    ->setNumeroSecuriteSociale('')
+                    ->setTelephone('0621436587')
             )
             ->setEmail('raquel.randt@courriel.fr')
             ->setVerifieCourriel(true)
-            ->setRoles([Requerant::ROLE_REQUERANT])
-        ;
+            ->setRoles([Requerant::ROLE_REQUERANT]);
 
         $requerant->setPassword($this->passwordHasher->hashPassword($requerant, 'P4ssword'));
 
@@ -93,7 +158,7 @@ class DossierFixture implements ORMFixtureInterface
             ->setRedacteur($redacteur)
             ->setTestEligibilite(
                 TestEligibilite::fromArray([
-                    'departement' => $manager->find(GeoDepartement::class, '13'),
+                    'departement' => $bouchesDuRhone,
                     'description' => 'Porte fracturée tôt ce matin',
                     'estVise' => false,
                     'estHebergeant' => false,
@@ -102,8 +167,7 @@ class DossierFixture implements ORMFixtureInterface
                     'requerant' => $requerant,
                     'dateSoumission' => new \DateTime('-30 seconds'),
                 ])
-            )
-        ;
+            );
 
         $manager->persist($dossier);
         $manager->flush();

--- a/src/Entity/GeoCodePostal.php
+++ b/src/Entity/GeoCodePostal.php
@@ -2,6 +2,7 @@
 
 namespace MonIndemnisationJustice\Entity;
 
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use MonIndemnisationJustice\Repository\GeoCodePostalRepository;
 
@@ -10,6 +11,7 @@ use MonIndemnisationJustice\Repository\GeoCodePostalRepository;
 #[ORM\Index(name: 'idx_code_postal', columns: ['code_postal'])]
 #[ORM\UniqueConstraint(name: 'unique_code_insee_postal', fields: ['codePostal', 'commune'])]
 #[ORM\HasLifecycleCallbacks]
+#[ApiResource(uriTemplate: '/api/geo-code-postal/{id}', operations: [])]
 class GeoCodePostal extends GeoDataEntity
 {
     #[ORM\Id]
@@ -24,6 +26,11 @@ class GeoCodePostal extends GeoDataEntity
     #[ORM\ManyToOne(targetEntity: GeoCommune::class, inversedBy: 'codePostaux')]
     #[ORM\JoinColumn(name: 'code_commune', referencedColumnName: 'code', nullable: false)]
     protected GeoCommune $commune;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
 
     public function getCodePostal(): string
     {

--- a/src/Entity/GeoCodePostal.php
+++ b/src/Entity/GeoCodePostal.php
@@ -23,7 +23,7 @@ class GeoCodePostal extends GeoDataEntity
     /** Le code postal */
     protected string $codePostal;
 
-    #[ORM\ManyToOne(targetEntity: GeoCommune::class, inversedBy: 'codePostaux')]
+    #[ORM\ManyToOne(targetEntity: GeoCommune::class, cascade: ['persist'], inversedBy: 'codePostaux')]
     #[ORM\JoinColumn(name: 'code_commune', referencedColumnName: 'code', nullable: false)]
     protected GeoCommune $commune;
 

--- a/src/Entity/GeoPays.php
+++ b/src/Entity/GeoPays.php
@@ -12,7 +12,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 #[ORM\Entity(repositoryClass: GeoPaysRepository::class)]
 #[ORM\HasLifecycleCallbacks]
 #[UniqueEntity(fields: ['codeInsee'], message: 'Ce code INSEE est déjà attribué à un pays')]
-#[ApiResource(uriTemplate: '/geo-pays/{code}')]
+#[ApiResource(uriTemplate: '/geo-pays/{code}', operations: [])]
 class GeoPays extends GeoDataEntity
 {
     #[ORM\Id]

--- a/src/Entity/GeoRegion.php
+++ b/src/Entity/GeoRegion.php
@@ -27,13 +27,22 @@ class GeoRegion
         return $this->code;
     }
 
+    public function setCode(string $code): self
+    {
+        $this->code = $code;
+
+        return $this;
+    }
+
     public function getNom(): string
     {
         return $this->nom;
     }
 
-    public function estDeploye(): bool
+    public function setNom(string $nom): self
     {
-        return $this->departements->forAll(fn (GeoDepartement $departement) => $departement->estDeploye());
+        $this->nom = $nom;
+
+        return $this;
     }
 }

--- a/src/Entity/PersonnePhysique.php
+++ b/src/Entity/PersonnePhysique.php
@@ -190,12 +190,12 @@ class PersonnePhysique
 
     public function getCommuneNaissance(): ?string
     {
-        return $this->communeNaissance;
+        return $this->codePostalNaissance?->getCommune()->getNom();
     }
 
-    public function setCommuneNaissance(?string $communeNaissance = null): static
+    public function setCommuneNaissance(?GeoCodePostal $codePostal = null): static
     {
-        $this->communeNaissance = $communeNaissance;
+        $this->codePostalNaissance = $codePostal;
 
         return $this;
     }
@@ -205,18 +205,6 @@ class PersonnePhysique
     public function getCodePostalNaissanceCode(): ?string
     {
         return $this->codePostalNaissance?->getCodePostal();
-    }
-
-    public function getCodePostalNaissance(): ?GeoCodePostal
-    {
-        return $this->codePostalNaissance;
-    }
-
-    public function setCodePostalNaissance(?GeoCodePostal $codePostalNaissance): PersonnePhysique
-    {
-        $this->codePostalNaissance = $codePostalNaissance;
-
-        return $this;
     }
 
     public function getPaysNaissance(): ?GeoPays

--- a/src/Entity/PersonnePhysique.php
+++ b/src/Entity/PersonnePhysique.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 use MonIndemnisationJustice\Repository\PersonnePhysiqueRepository;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Attribute\Context;
+use Symfony\Component\Serializer\Attribute\SerializedName;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
 #[ORM\Entity(repositoryClass: PersonnePhysiqueRepository::class)]
@@ -53,10 +54,12 @@ class PersonnePhysique
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $telephone = null;
 
-    #[Groups(['dossier:lecture', 'dossier:patch'])]
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $communeNaissance = null;
 
+    #[Groups(['dossier:lecture', 'dossier:patch'])]
+    #[ApiProperty(readableLink: false, writableLink: false, genId: true)]
+    #[SerializedName('communeNaissance')]
     #[ORM\ManyToOne(targetEntity: GeoCodePostal::class)]
     #[ORM\JoinColumn(name: 'code_postal_naissance_id', referencedColumnName: 'id')]
     protected ?GeoCodePostal $codePostalNaissance = null;
@@ -195,6 +198,13 @@ class PersonnePhysique
         $this->communeNaissance = $communeNaissance;
 
         return $this;
+    }
+
+    #[SerializedName('codePostalNaissance')]
+    #[Groups(['dossier:lecture'])]
+    public function getCodePostalNaissanceCode(): ?string
+    {
+        return $this->codePostalNaissance?->getCodePostal();
     }
 
     public function getCodePostalNaissance(): ?GeoCodePostal

--- a/src/Entity/Requerant.php
+++ b/src/Entity/Requerant.php
@@ -34,7 +34,7 @@ class Requerant implements UserInterface, PasswordAuthenticatedUserInterface
 
     #[Groups(['user:read', 'dossier:lecture'])]
     #[ORM\Column(length: 180)]
-    private ?string $email = null;
+    protected ?string $email = null;
 
     /**
      * @var list<string> The user roles
@@ -110,7 +110,7 @@ class Requerant implements UserInterface, PasswordAuthenticatedUserInterface
         return $this->id;
     }
 
-    #[Groups('agent:detail')]
+    #[Groups(['agent:detail', 'dossier:detail'])]
     #[SerializedName('courriel')]
     public function getEmail(): ?string
     {
@@ -156,9 +156,9 @@ class Requerant implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
-     * @see UserInterface
-     *
      * @return list<string>
+     *
+     * @see UserInterface
      */
     public function getRoles(): array
     {
@@ -407,7 +407,7 @@ class Requerant implements UserInterface, PasswordAuthenticatedUserInterface
     public function getNomComplet(): string
     {
         return ($this->isPersonneMorale ?
-            "la société {$this->personneMorale->getRaisonSociale()} représentée par " : '').$this->personnePhysique->getNomComplet();
+                "la société {$this->personneMorale->getRaisonSociale()} représentée par " : '').$this->personnePhysique->getNomComplet();
     }
 
     public function getDernierDossier(): ?BrisPorte

--- a/src/Security/Authenticator/FranceConnectAuthenticator.php
+++ b/src/Security/Authenticator/FranceConnectAuthenticator.php
@@ -51,11 +51,10 @@ class FranceConnectAuthenticator extends AbstractAuthenticator
                 || $this->httpUtils->checkRequestPath($request, $this->loginCheckRoute)
             )
             && $request->query->has('state')
-                && (
-                    $request->query->has('code')
-                    || $request->query->has('error')
-                )
-        ;
+            && (
+                $request->query->has('code')
+                || $request->query->has('error')
+            );
     }
 
     public function authenticate(Request $request): Passport
@@ -80,12 +79,12 @@ class FranceConnectAuthenticator extends AbstractAuthenticator
                         ->setPersonnePhysique(
                             (new PersonnePhysique())
                                 ->setCivilite('male' === $userInfo['gender'] ? Civilite::M : Civilite::MME)
-                            ->setNom($userInfo['family_name'] ?? '')
-                            ->setPrenom1($prenoms[0] ?? null)
-                            ->setPrenom2($prenoms[1] ?? null)
-                            ->setPrenom3($prenoms[2] ?? null)
-                            ->setDateNaissance(new \DateTime($userInfo['birthdate'] ?? ''))
-                            ->setEmail($userInfo['email'] ?? null)
+                                ->setNom($userInfo['family_name'] ?? '')
+                                ->setPrenom1($prenoms[0] ?? null)
+                                ->setPrenom2($prenoms[1] ?? null)
+                                ->setPrenom3($prenoms[2] ?? null)
+                                ->setDateNaissance(new \DateTime($userInfo['birthdate'] ?? ''))
+                                ->setEmail($userInfo['email'] ?? null)
                         );
 
                     // Récupération du pays de naissance
@@ -105,9 +104,7 @@ class FranceConnectAuthenticator extends AbstractAuthenticator
 
                         if (null !== $codePostalNaissance) {
                             $requerant->getPersonnePhysique()
-                                ->setCodePostalNaissance($codePostalNaissance)
-                                ->setCommuneNaissance($codePostalNaissance->getCommune()->getNom())
-                            ;
+                                ->setCommuneNaissance($codePostalNaissance);
                         }
                     }
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -24,6 +24,13 @@
         input[type=radio], input[type=checkbox] {
             z-index: 2 !important;
         }
+
+        body {
+            > main {
+                margin-top: 2rem;
+            }
+        }
+
     </style>
     {% block stylesheets %}{% endblock stylesheets %}
     <title>{% block title %}Mon indemnisation justice{% if title is defined %} - {{ title }}{% endif %}{% endblock %}</title>

--- a/tests/Controller/BrisPorteControllerTest.php
+++ b/tests/Controller/BrisPorteControllerTest.php
@@ -45,20 +45,19 @@ class BrisPorteControllerTest extends WebTestCase
         $requerant = (new Requerant())
             ->setAdresse(
                 (new Adresse())
-                ->setLigne1('12 rue des Oliviers')
-                ->setLocalite('Nantes')
-                ->setCodePostal('44100')
+                    ->setLigne1('12 rue des Oliviers')
+                    ->setLocalite('Nantes')
+                    ->setCodePostal('44100')
             )
             ->setPersonnePhysique(
                 (new PersonnePhysique())
-                ->setEmail('raquel.randt@courriel.fr')
-                ->setCivilite(Civilite::MME)
-                ->setPrenom1('Raquel')
-                ->setNom('Randt')
+                    ->setEmail('raquel.randt@courriel.fr')
+                    ->setCivilite(Civilite::MME)
+                    ->setPrenom1('Raquel')
+                    ->setNom('Randt')
             )
             ->setEmail('raquel.randt@courriel.fr')
-            ->setRoles([Requerant::ROLE_REQUERANT])
-        ;
+            ->setRoles([Requerant::ROLE_REQUERANT]);
         $requerant->setPassword($this->passwordHasher->hashPassword($requerant, 'P4ssword'));
 
         $this->em->persist($requerant);


### PR DESCRIPTION
# Réconcilier les données de communes naissance

Depuis la mise en place de FranceConnect, on reçoit les codes INSEE de commune de naissance. Idéal pour générer les 10 premiers chiffres du numéro de sécu.

L'objectif ici est de basculer l'usage de `PersonnePhysique::communeNaissance` vers `PersonnePhysique::codePostalNaissance`.

La requête SQL pour tenter la réconciliation (requiert `fuzzystrmatch` et `unaccent`):

```sql
select distinct on (d.id, pp.id)
    d.id,
    pp.id,
    gcp.id,
    -- gc.code,
    pp.commune_naissance,
    gc.nom,
    levenshtein(lower(unaccent(gc.nom)), lower(regexp_replace(unaccent(pp.commune_naissance), '\s+\d+$', '')), 3, 3, 1)  as distance,
    gc.nb_communes
from bris_porte d
    inner join requerants r on d.requerant_id = r.id
    inner join personne_physique pp on r.personne_physique_id = pp.id
    cross join (
        select gc.nom, count(gc.code) as nb_communes, min(gc.code) as code
        from geo_communes gc
        group by gc.nom
        order by nb_communes desc
    ) gc
    left join (
        select distinct on (gcp.code_commune, gcp.code_postal) *
        from geo_codes_postaux gcp
        order by gcp.code_commune, gcp.code_postal desc
    ) gcp on gc.code = gcp.code_commune
where not exists(
    select *
    from dossier_etats
    where
        dossier_id = d.id
        and etat = 'A_INSTRUIRE'
)
    and pp.pays_naissance = 'FRA'
    and pp.commune_naissance is not null
    and trim(pp.commune_naissance) <> ''
order by d.id, pp.id, distance;
```