### PR TITLE
Nettoyer les données de naissance

### DIFF
--- a/migrations/Version20250620133536.php
+++ b/migrations/Version20250620133536.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250620133536 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Nettoyage sur les données de naissance';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE INDEX idx_pays_code_insee ON geo_pays (code_insee)');
+        $this->addSql("update geo_pays set code_insee = '99157' where code = 'KOS'");
+        $this->addSql('ALTER TABLE personne_physique DROP commune_naissance');
+        $this->addSql(<<<SQL
+update personne_physique
+set pays_naissance = 'FRA'
+where code_postal_naissance_id is not null
+    and pays_naissance is null;
+SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX idx_pays_code_insee');
+        $this->addSql('ALTER TABLE personne_physique ADD commune_naissance VARCHAR(255) DEFAULT NULL');
+    }
+}

--- a/src/Command/RecalculerNumeroSecuCommand.php
+++ b/src/Command/RecalculerNumeroSecuCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MonIndemnisationJustice\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use MonIndemnisationJustice\Entity\PersonnePhysique;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'mij:secu:recalculer', description: 'Supprimer requérant')]
+class RecalculerNumeroSecuCommand extends Command
+{
+    public function __construct(
+        protected readonly EntityManagerInterface $em,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $personnes = $this->em->getRepository(PersonnePhysique::class)->findAll();
+
+        foreach ($personnes as $personne) {
+            if (null !== $personne->getCivilite() && null !== $personne->getDateNaissance() && (null !== $personne->getCodePostalNaissanceCode() || !$personne->getPaysNaissance()?->estFrance())) {
+                $personne->recalculerNumeroSecuriteSociale();
+                $this->em->persist($personne);
+            }
+        }
+
+        $this->em->flush();
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/DataFixtures/DossierFixture.php
+++ b/src/DataFixtures/DossierFixture.php
@@ -17,7 +17,6 @@ use MonIndemnisationJustice\Entity\GeoRegion;
 use MonIndemnisationJustice\Entity\PersonnePhysique;
 use MonIndemnisationJustice\Entity\Requerant;
 use MonIndemnisationJustice\Entity\TestEligibilite;
-use MonIndemnisationJustice\Service\DataGouv\ImporteurGeoPays;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class DossierFixture implements ORMFixtureInterface
@@ -33,7 +32,7 @@ class DossierFixture implements ORMFixtureInterface
 
         $france = (new GeoPays())
             ->setCode('FRA')
-            ->setCodeInsee(ImporteurGeoPays::CODE_INSEE_FRANCE)
+            ->setCodeInsee(GeoPays::CODE_INSEE_FRANCE)
             ->setNom('France');
 
         $manager->persist($france);
@@ -142,7 +141,6 @@ class DossierFixture implements ORMFixtureInterface
                     ->setDateNaissance(new \DateTime('1979-05-17'))
                     ->setCommuneNaissance($codePostal38300)
                     ->setPaysNaissance($france)
-                    ->setNumeroSecuriteSociale('')
                     ->setTelephone('0621436587')
             )
             ->setEmail('raquel.randt@courriel.fr')

--- a/src/Entity/Civilite.php
+++ b/src/Entity/Civilite.php
@@ -23,6 +23,17 @@ enum Civilite: string
         };
     }
 
+    /**
+     * Le code pour la sécurité sociale.
+     */
+    public function getCode(): int
+    {
+        return match ($this) {
+            Civilite::M => 1,
+            Civilite::MME => 2,
+        };
+    }
+
     public function libelleNaissance(string $nomNaissance): string
     {
         return sprintf('né%s %s', $this->estFeminin() ? 'e' : '', $nomNaissance);

--- a/src/Entity/GeoPays.php
+++ b/src/Entity/GeoPays.php
@@ -5,16 +5,17 @@ namespace MonIndemnisationJustice\Entity;
 use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use MonIndemnisationJustice\Repository\GeoPaysRepository;
-use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ORM\Table(name: 'geo_pays')]
 #[ORM\Entity(repositoryClass: GeoPaysRepository::class)]
 #[ORM\HasLifecycleCallbacks]
-#[UniqueEntity(fields: ['codeInsee'], message: 'Ce code INSEE est déjà attribué à un pays')]
+#[ORM\Index(name: 'idx_pays_code_insee', columns: ['code_insee'])]
 #[ApiResource(uriTemplate: '/geo-pays/{code}', operations: [])]
 class GeoPays extends GeoDataEntity
 {
+    public const CODE_INSEE_FRANCE = '99100';
+
     #[ORM\Id]
     #[ORM\Column(length: 3)]
     #[Groups(['dossier:lecture'])]
@@ -54,6 +55,11 @@ class GeoPays extends GeoDataEntity
     public function getCodeInsee(): ?string
     {
         return $this->codeInsee;
+    }
+
+    public function estFrance(): bool
+    {
+        return self::CODE_INSEE_FRANCE === $this->codeInsee;
     }
 
     public function setCodeInsee(?string $codeInsee): GeoPays

--- a/src/Repository/GeoPaysRepository.php
+++ b/src/Repository/GeoPaysRepository.php
@@ -34,4 +34,9 @@ class GeoPaysRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    public function getFrance(): GeoPays
+    {
+        return $this->findOneBy(['codeFrance' => GeoPays::CODE_INSEE_FRANCE]);
+    }
 }

--- a/src/Security/Authenticator/FranceConnectAuthenticator.php
+++ b/src/Security/Authenticator/FranceConnectAuthenticator.php
@@ -90,7 +90,9 @@ class FranceConnectAuthenticator extends AbstractAuthenticator
                     // Récupération du pays de naissance
                     if (null !== ($codePaysNaissance = $userInfo['birthcountry'])) {
                         /** @var GeoPays $paysNaissance */
-                        $paysNaissance = $this->em->getRepository(GeoPays::class)->find($codePaysNaissance);
+                        $paysNaissance = $this->em->getRepository(GeoPays::class)->findOneBy([
+                            'codeInsee' => $codePaysNaissance]
+                        );
 
                         if (null !== $paysNaissance) {
                             $requerant->getPersonnePhysique()->setPaysNaissance($paysNaissance);
@@ -104,7 +106,8 @@ class FranceConnectAuthenticator extends AbstractAuthenticator
 
                         if (null !== $codePostalNaissance) {
                             $requerant->getPersonnePhysique()
-                                ->setCommuneNaissance($codePostalNaissance);
+                                ->setCommuneNaissance($codePostalNaissance)
+                                ->setPaysNaissance($this->em->getRepository(GeoPays::class)->getFrance());
                         }
                     }
 

--- a/src/Service/DataGouv/ImporteurGeoPays.php
+++ b/src/Service/DataGouv/ImporteurGeoPays.php
@@ -7,10 +7,6 @@ use MonIndemnisationJustice\Entity\GeoPays;
 
 class ImporteurGeoPays implements DataGouvProcessor
 {
-    // Une valeur particulière est attribuée à la France côté FranceConnect https://docs.partenaires.franceconnect.gouv.fr/fs/fs-technique/fs-technique-scope-fc/#liste-des-claims
-    // mais pas renseignée sur la source data.gouv.fr
-    public const CODE_INSEE_FRANCE = '99100';
-
     // Référentiel des pays et des territoires https://www.data.gouv.fr/fr/datasets/referentiel-des-pays-et-des-territoires/#/resources/2b38f28d-15e7-4f0c-b61d-6ca1d9b1cfa2
     private const RESOURCE_GEO_PAYS = '2b38f28d-15e7-4f0c-b61d-6ca1d9b1cfa2';
 
@@ -32,7 +28,7 @@ class ImporteurGeoPays implements DataGouvProcessor
 
             $pays
                 ->setNom($record['NOM_COURT'])
-                ->setCodeInsee('FRA' === $record['ISO_alpha3'] ? self::CODE_INSEE_FRANCE : $record['CODE_COG']);
+                ->setCodeInsee('FRA' === $record['ISO_alpha3'] ? GeoPays::CODE_INSEE_FRANCE : $record['CODE_COG']);
 
             $this->entityManager->persist($pays);
             $this->entityManager->flush();


### PR DESCRIPTION
# Nettoyer les données de naissance

En vue de générer automatiquement le numéro de sécu avant chaque sauvegarde des données de personne physique.

On en profite pour corriger une erreur d'identification du pays de naissance.