### PR TITLE
Permettre au rédacteur de modifier la PI

### DIFF
--- a/assets/apps/agent/dossiers/models/Document.ts
+++ b/assets/apps/agent/dossiers/models/Document.ts
@@ -12,13 +12,6 @@ export class DocumentType {
     public readonly estRequerant: boolean = true,
   ) {}
 
-  estAjoutableAgent(): boolean {
-    return ![
-      DocumentType.TYPE_COURRIER_MINISTERE,
-      DocumentType.TYPE_ARRETE_PAIEMENT,
-    ].includes(this);
-  }
-
   public static readonly TYPE_ATTESTATION_INFORMATION = new DocumentType(
     "attestation_information",
     "Attestation à remettre en cas d'erreur de porte",

--- a/assets/apps/agent/dossiers/models/Dossier.ts
+++ b/assets/apps/agent/dossiers/models/Dossier.ts
@@ -73,6 +73,9 @@ export abstract class BaseDossier {
       this.etat.etat,
     );
   }
+  get estAApprouver(): boolean {
+    return [EtatDossierType.OK_A_APPROUVER].includes(this.etat.etat);
+  }
 
   get estAVerifier(): boolean {
     return [EtatDossierType.OK_A_VERIFIER].includes(this.etat.etat);

--- a/src/Entity/DocumentType.php
+++ b/src/Entity/DocumentType.php
@@ -47,6 +47,17 @@ enum DocumentType: string
         };
     }
 
+    public function estUnique(): bool
+    {
+        return match ($this) {
+            self::TYPE_COURRIER_MINISTERE,
+            self::TYPE_COURRIER_REQUERANT,
+            self::TYPE_ARRETE_PAIEMENT => true,
+
+            default => false,
+        };
+    }
+
     /**
      * Retourne le chemin vers le gabarit (i.e. "template") twig à utiliser pour la génération du document.
      */


### PR DESCRIPTION
# Permettre au rédacteur de modifier la PI

Depuis la section des pièces jointes, le type `COURRIER_MINISTERE` est désormais disponible pour l'ajout.

Si dans l'état `À approuver`, le montant peut-être changé et un email sera transmis au requérant pour le notifier du changement de décision.