### PR TITLE
Correctif : les pièces jointes n'apparaissent pas toutes sur la page de récap du dépôt de dossier

### DIFF
--- a/.docker/php/fichiers/.gitignore
+++ b/.docker/php/fichiers/.gitignore
@@ -1,3 +1,2 @@
 *
-
 !.gitignore

--- a/assets/apps/requerant/dossier/components/BrisPorte/Recapitulatif.tsx
+++ b/assets/apps/requerant/dossier/components/BrisPorte/Recapitulatif.tsx
@@ -143,10 +143,10 @@ const Recapitulatif = ({
           )}
 
           <Document
-            documents={dossier.documents.preuve_paiement_facture}
+            documents={dossier.documents.facture}
             lectureSeule={true}
-            libelle="Facture acquittée attestant de la réalité des travaux de remise en état à l'identique "
-            type={"preuve_paiement_facture"}
+            libelle="Facture acquittée attestant de la réalité des travaux de remise en état à l'identique"
+            type={"facture"}
           />
           <Document
             documents={dossier.documents.rib}
@@ -159,16 +159,16 @@ const Recapitulatif = ({
             type={"rib"}
           />
 
-          {dossier.requerant.qualiteRequerant === "PRO" && (
+          {dossier.qualiteRequerant === "PRO" && (
             <Document
-              documents={dossier.documents.titre_de_propriete}
+              documents={dossier.documents.titre_propriete}
               lectureSeule={true}
               libelle="Titre de propriété"
               type={"titre_propriete"}
             />
           )}
 
-          {dossier.requerant.qualiteRequerant === "LOC" && (
+          {dossier.qualiteRequerant === "LOC" && (
             <Document
               documents={dossier.documents.contrat_location}
               lectureSeule={true}
@@ -177,16 +177,24 @@ const Recapitulatif = ({
             />
           )}
 
-          {dossier.requerant.qualiteRequerant === "LOC" && (
+          {dossier.qualiteRequerant === "LOC" && (
             <Document
-              documents={dossier.documents.non_prise_en_charge_assurance}
+              documents={dossier.documents.non_prise_en_charge_bailleur}
               lectureSeule={true}
               libelle={
                 "Attestation de non prise en charge par l'assurance habitation"
               }
-              type={"non_prise_en_charge_assurance"}
+              type={"non_prise_en_charge_bailleur"}
             />
           )}
+          <Document
+            documents={dossier.documents.non_prise_en_charge_assurance}
+            lectureSeule={true}
+            libelle={
+              "Attestation de non prise en charge par l'assurance habitation"
+            }
+            type={"non_prise_en_charge_assurance"}
+          />
         </section>
       </div>
     </div>

--- a/assets/apps/requerant/dossier/components/BrisPortePanel.tsx
+++ b/assets/apps/requerant/dossier/components/BrisPortePanel.tsx
@@ -258,7 +258,7 @@ const BrisPortePanel = function () {
               </section>
             </div>
             {/* Est propriétaire */}
-            {dossier.requerant.personnePhysique.qualiteRequerant === "PRO" && (
+            {dossier.qualiteRequerant === "PRO" && (
               <div className="fr-col-12">
                 <section className="pr-form-section">
                   <Document
@@ -292,7 +292,7 @@ const BrisPortePanel = function () {
               </div>
             )}
             {/* Est locataire */}
-            {dossier.requerant.personnePhysique.qualiteRequerant === "LOC" && (
+            {dossier.qualiteRequerant === "LOC" && (
               <div className="fr-col-12">
                 <section className="pr-form-section">
                   <Document
@@ -326,7 +326,7 @@ const BrisPortePanel = function () {
               </div>
             )}
             {/* Est locataire */}
-            {dossier.requerant.personnePhysique.qualiteRequerant === "LOC" && (
+            {dossier.qualiteRequerant === "LOC" && (
               <div className="fr-col-12">
                 <section className="pr-form-section">
                   <Document

--- a/assets/apps/requerant/dossier/deposer_mon_dossier.tsx
+++ b/assets/apps/requerant/dossier/deposer_mon_dossier.tsx
@@ -77,7 +77,7 @@ const apiPatch = () => {
   if (Object.keys(queuedChanges).length > 0) {
     window.appPendingChanges = true;
     // Run a PATCH call and store the result as state
-    fetch(`/api/requerant/dossier/${dossier.id}`, {
+    fetch(`/api-v1/requerant/dossier/${dossier.id}`, {
       method: "PATCH",
       redirect: "error",
       headers: { "Content-Type": "application/merge-patch+json" },

--- a/assets/common/models/Agent.ts
+++ b/assets/common/models/Agent.ts
@@ -1,5 +1,5 @@
-import { BaseDossier } from "@/apps/agent/dossiers/models/Dossier";
-import { Redacteur } from "@/apps/agent/dossiers/models/Redacteur";
+import { BaseDossier } from "@/common/models/Dossier";
+import { Redacteur } from "@/common/models/Redacteur";
 import { Transform } from "class-transformer";
 
 export enum AgentPermissionType {


### PR DESCRIPTION
# Correctif : les pièces jointes n'apparaissent pas toutes sur la page de récap du dépôt de dossier

cf. [tache Trello](https://trello.com/c/m9399LGl/244-%F0%9F%94%A5-correctif-les-pi%C3%A8ces-jointes-napparaissent-pas-toutes-sur-la-page-de-r%C3%A9cap-du-d%C3%A9p%C3%B4t-de-dossier): certaines pièces jointes ajoutées au dossier, lors du dépôt, n'apparraissent pas sur la récapitulatif