### PR TITLE
Afficher coordonnées aux agents validateurs et Beta

### DIFF
--- a/assets/apps/agent/dossiers/components/ConsultationDossierApp.tsx
+++ b/assets/apps/agent/dossiers/components/ConsultationDossierApp.tsx
@@ -15,6 +15,7 @@ import {
   ouvrirModaleSuppressionPieceJointe,
   SuppressionPieceJointe,
 } from "@/apps/agent/dossiers/components/consultation/piecejointe/SuppressionPieceJointe.tsx";
+import { Button } from "@codegouvfr/react-dsfr/Button";
 
 export const ConsultationDossierApp = observer(
   function ConsultationDossierAppComponent({
@@ -242,7 +243,8 @@ export const ConsultationDossierApp = observer(
                           )}
                           <li>
                             <b>Adresse courriel: </b>{" "}
-                            {dossier.enAttenteInstruction() ? (
+                            {dossier.enAttenteInstruction() &&
+                            agent.estRedacteur() ? (
                               <>
                                 <span aria-describedby="tooltip-requerant-courriel">{`${dossier.requerant.courriel.substring(0, 2)}${"*".repeat(dossier.requerant.courriel.length - 2)}`}</span>
                                 <span
@@ -255,27 +257,60 @@ export const ConsultationDossierApp = observer(
                                 </span>
                               </>
                             ) : (
-                              <span>{dossier.requerant.courriel}</span>
+                              <>
+                                <span>{dossier.requerant.courriel}</span>
+                                <Button
+                                  iconId="fr-icon-clipboard-line"
+                                  onClick={() =>
+                                    navigator.clipboard.writeText(
+                                      dossier.requerant.courriel,
+                                    )
+                                  }
+                                  priority="tertiary no outline"
+                                  title="Copier dans le presse papier"
+                                  size="small"
+                                />
+                              </>
                             )}
                           </li>
+                          {agent.estRedacteur() ||
+                            agent.estValidateur() ||
+                            agent.estBetagouv()}
                           <li>
                             <b>N° téléphone: </b>
                             {dossier.requerant.telephone ? (
-                              dossier.enAttenteInstruction() ? (
-                                <>
-                                  <span aria-describedby="tooltip-requerant-telephone">{`${dossier.requerant.telephone.substring(0, 2)}${"*".repeat(dossier.requerant.telephone.length - 2)}`}</span>
-                                  <span
-                                    className="fr-tooltip fr-placement"
-                                    id="tooltip-requerant-telephone"
-                                    role="tooltip"
-                                    aria-hidden="true"
-                                  >
-                                    Démarrer l'instruction pour révéler
-                                  </span>
-                                </>
-                              ) : (
-                                <>{dossier.requerant.telephone}</>
-                              )
+                              <>
+                                {dossier.enAttenteInstruction() &&
+                                agent.estRedacteur() ? (
+                                  <>
+                                    <span aria-describedby="tooltip-requerant-telephone">{`${dossier.requerant.telephone.substring(0, 2)}${"*".repeat(dossier.requerant.telephone.length - 2)}`}</span>
+                                    <span
+                                      className="fr-tooltip fr-placement"
+                                      id="tooltip-requerant-telephone"
+                                      role="tooltip"
+                                      aria-hidden="true"
+                                    >
+                                      Démarrer l'instruction pour révéler
+                                    </span>
+                                  </>
+                                ) : (
+                                  <>
+                                    {dossier.requerant.telephone}
+                                    <Button
+                                      style={{ display: "inline-block" }}
+                                      iconId="fr-icon-clipboard-line"
+                                      onClick={() =>
+                                        navigator.clipboard.writeText(
+                                          dossier.requerant.telephone,
+                                        )
+                                      }
+                                      priority="tertiary no outline"
+                                      title="Copier dans le presse papier"
+                                      size="small"
+                                    />
+                                  </>
+                                )}
+                              </>
                             ) : (
                               <i>non renseigné</i>
                             )}
@@ -375,6 +410,14 @@ export const ConsultationDossierApp = observer(
                                   ? "Oui"
                                   : "Non"}
                               </>
+                            </li>
+                          )}
+                          {dossier.testEligibilite.description && (
+                            <li>
+                              <b>Commentaires du requérant:</b>
+                              <blockquote>
+                                {dossier.testEligibilite.description}
+                              </blockquote>
                             </li>
                           )}
                         </ul>

--- a/assets/common/models/Agent.ts
+++ b/assets/common/models/Agent.ts
@@ -1,5 +1,5 @@
-import { BaseDossier } from "@/apps/agent/dossiers/models/Dossier";
-import { Redacteur } from "@/apps/agent/dossiers/models/Redacteur";
+import { BaseDossier } from "@/common/models/Dossier";
+import { Redacteur } from "@/common/models/Redacteur";
 import { Transform } from "class-transformer";
 
 export enum AgentPermissionType {
@@ -7,13 +7,15 @@ export enum AgentPermissionType {
   ATTRIBUTEUR = "ATTRIBUTEUR",
   VALIDATEUR = "VALIDATEUR",
   LIAISON_BUDGET = "LIAISON_BUDGET",
+  BETAGOUV = "BETAGOUV",
 }
 
 export type AgentPermission =
   | AgentPermissionType.REDACTEUR
   | AgentPermissionType.ATTRIBUTEUR
   | AgentPermissionType.VALIDATEUR
-  | AgentPermissionType.LIAISON_BUDGET;
+  | AgentPermissionType.LIAISON_BUDGET
+  | AgentPermissionType.BETAGOUV;
 
 export class Agent {
   public id: number;
@@ -35,6 +37,10 @@ export class Agent {
 
   public estLiaisonBudget(): boolean {
     return this.permissions.has(AgentPermissionType.LIAISON_BUDGET);
+  }
+
+  public estBetagouv(): boolean {
+    return this.permissions.has(AgentPermissionType.BETAGOUV);
   }
 
   public instruit(dossier: BaseDossier): boolean {

--- a/src/Controller/Agent/DossierController.php
+++ b/src/Controller/Agent/DossierController.php
@@ -97,6 +97,7 @@ class DossierController extends AgentController
                         $this->getAgent()->hasRole(Agent::ROLE_AGENT_REDACTEUR) ? ['REDACTEUR'] : [],
                         $this->getAgent()->hasRole(Agent::ROLE_AGENT_VALIDATEUR) ? ['VALIDATEUR'] : [],
                         $this->getAgent()->hasRole(Agent::ROLE_AGENT_LIAISON_BUDGET) ? ['LIAISON_BUDGET'] : [],
+                        $this->getAgent()->hasRole(Agent::ROLE_AGENT_BETAGOUV) ? ['BETAGOUV'] : [],
                     ),
                 ],
                 'dossier' => $normalizer->normalize($dossier, 'json', ['groups' => 'agent:detail']),

--- a/src/Entity/Agent.php
+++ b/src/Entity/Agent.php
@@ -20,6 +20,7 @@ class Agent implements UserInterface
 {
     // Le role ROLE_AGENT est donné à chaque agent de la fonction publique
     public const ROLE_AGENT = 'ROLE_AGENT';
+    public const ROLE_AGENT_BETAGOUV = 'ROLE_AGENT_BETAGOUV';
     // Le role ROLE_AGENT_DOSSIER permet de chercher et consulter un dossier
     public const ROLE_AGENT_DOSSIER = 'ROLE_AGENT_DOSSIER';
 

--- a/src/Security/Authenticator/ProConnectAuthenticator.php
+++ b/src/Security/Authenticator/ProConnectAuthenticator.php
@@ -46,11 +46,10 @@ class ProConnectAuthenticator extends AbstractAuthenticator
         return
             $this->httpUtils->checkRequestPath($request, $this->loginCheckRoute)
             && $request->query->has('state')
-                && (
-                    $request->query->has('code')
-                    || $request->query->has('error')
-                )
-        ;
+            && (
+                $request->query->has('code')
+                || $request->query->has('error')
+            );
     }
 
     public function authenticate(Request $request): Passport
@@ -66,28 +65,29 @@ class ProConnectAuthenticator extends AbstractAuthenticator
 
             if (null === $agent) {
                 $agent = ($this->agentRepository->findOneBy(['email' => $userInfo['email']]) ?? new Agent())
-                ->setIdentifiant($userInfo['sub'])
-                ->setEmail($userInfo['email'])
-                ->setPrenom($userInfo['given_name'])
-                ->setNom($userInfo['usual_name'])
-                ->addRole(Agent::ROLE_AGENT)
-                ->setUid($userInfo['uid'])
-                ->setCree()
-                ->setFournisseurIdentite($this->fournisseurIdentiteAgentRepository->find($userInfo['idp_id']))
-                ->setDonnesAuthentification($userInfo)
-                ;
+                    ->setIdentifiant($userInfo['sub'])
+                    ->setEmail($userInfo['email'])
+                    ->setPrenom($userInfo['given_name'])
+                    ->setNom($userInfo['usual_name'])
+                    ->addRole(Agent::ROLE_AGENT)
+                    ->setUid($userInfo['uid'])
+                    ->setCree()
+                    ->setFournisseurIdentite($this->fournisseurIdentiteAgentRepository->find($userInfo['idp_id']))
+                    ->setDonnesAuthentification($userInfo);
 
                 if (in_array(sha1($agent->getEmail()), $this->autoPromotionHashes ?? [])) {
                     $agent
                         ->addRole(Agent::ROLE_AGENT_GESTION_PERSONNEL)
                         ->addRole(Agent::ROLE_AGENT_REDACTEUR)
+                        ->addRole(Agent::ROLE_AGENT_BETAGOUV)
                         ->setAdministration(Administration::MINISTERE_JUSTICE)
                         ->setValide();
                 }
             } else {
                 $agent->setEmail($userInfo['email'])
-                ->setPrenom($userInfo['given_name'])
-                ->setNom($userInfo['usual_name']);
+                    ->setPrenom($userInfo['given_name'])
+                    ->addRole(Agent::ROLE_AGENT_BETAGOUV)
+                    ->setNom($userInfo['usual_name']);
 
                 // Rattrapage des donées 'custom' pour les agents connectés avant l'intégration de ces données
                 // supplémentaires https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/custom-scope


### PR DESCRIPTION
# Afficher coordonnées aux agents validateurs et Beta

Et ne plus être bloqué en attendant le début de l'instruction comme les rédacteurs.

🎁 Bonus: les coordonnées sont désormais copiables dans le presse-papier