### PR TITLE
Améliorer le traitement des documents

### DIFF
--- a/backend/src/Controller/Requerant/DocumentController.php
+++ b/backend/src/Controller/Requerant/DocumentController.php
@@ -100,7 +100,7 @@ class DocumentController extends AbstractController
                 ]
             );
         } catch (FileException $e) {
-            $this->logger->warning('Fichier de pièce jointe introuvable', ['id' => $document->getId()]);
+            $this->logger->warning('Fichier de pièce jointe introuvable', ['id' => $document->getId(), 'erreur' => $e->getMessage()]);
 
             return new Response('', Response::HTTP_NOT_FOUND);
         }

--- a/backend/src/Entity/BrisPorte.php
+++ b/backend/src/Entity/BrisPorte.php
@@ -651,6 +651,11 @@ class BrisPorte
         }
     }
 
+    public function getOrCreateDocument(DocumentType $type): Document
+    {
+        return $this->getDocumentParType($type) ?? (new Document())->setType($type)->ajouterAuDossier($this);
+    }
+
     protected function getDateEtat(EtatDossierType $etat): ?\DateTimeInterface
     {
         return $this->historiqueEtats
@@ -658,10 +663,5 @@ class BrisPorte
                 fn (int $index, EtatDossier $e) => $etat === $e->getEtat()
             )?->getDate()
         ;
-    }
-
-    protected function getOrCreateDocument(DocumentType $type): Document
-    {
-        return $this->getDocumentParType($type) ?? (new Document())->setType($type)->ajouterAuDossier($this);
     }
 }


### PR DESCRIPTION
# Améliorer le traitement des documents

Régulièrement des pièces jointes sont téléversées et créées alors que le fichier correspondant est introuvable.

Ici on centralise la gestion de l'ajout au service `DocumentManager` et on rajoute une double vérification après la copie.