### PR TITLE
🔥  Capter les erreurs FranceConnect avec Sentry

### DIFF
--- a/backend/config/packages/monolog.yaml
+++ b/backend/config/packages/monolog.yaml
@@ -22,6 +22,9 @@ when@dev:
         type: console
         process_psr_3_messages: false
         channels: [ "!event", "!doctrine", "!console" ]
+      sentry_logs:
+        type: service
+        id: Sentry\SentryBundle\Monolog\LogsHandler
 
 when@test:
   monolog:

--- a/backend/config/packages/sentry.yaml
+++ b/backend/config/packages/sentry.yaml
@@ -1,14 +1,24 @@
 when@prod: &prod
-    sentry:
-        # See https://docs.sentry.io/platforms/php/guides/symfony/configuration/
-        dsn: '%env(default::SENTRY_DSN)%'
-        options:
-            ignore_exceptions:
-                - 'Symfony\Component\ErrorHandler\Error\FatalError'
-                - 'Symfony\Component\Debug\Exception\FatalErrorException'
-                - 'Symfony\Component\HttpKernel\Exception\HttpException'
-                - 'Symfony\Component\Security\Core\Exception\AccessDeniedException'
-                - 'Symfony\Component\Console\Exception\CommandNotFoundException'
-            send-default-pii: true
+  sentry:
+    # See https://docs.sentry.io/platforms/php/guides/symfony/configuration/
+    dsn: '%env(default::SENTRY_DSN)%'
+    options:
+      environment: "%kernel.environment%"
+      ignore_exceptions:
+        - 'Symfony\Component\ErrorHandler\Error\FatalError'
+        - 'Symfony\Component\Debug\Exception\FatalErrorException'
+        - 'Symfony\Component\HttpKernel\Exception\HttpException'
+        - 'Symfony\Component\Security\Core\Exception\AccessDeniedException'
+        - 'Symfony\Component\Console\Exception\CommandNotFoundException'
+      send-default-pii: true
+      enable_logs: true
 
 when@develop: *prod
+
+when@dev: *prod
+
+
+services:
+  Sentry\SentryBundle\Monolog\LogsHandler:
+    arguments:
+      - !php/const Monolog\Logger::INFO

--- a/backend/src/Controller/SecurityController.php
+++ b/backend/src/Controller/SecurityController.php
@@ -10,10 +10,10 @@ use MonIndemnisationJustice\Entity\Requerant;
 use MonIndemnisationJustice\Forms\ModificationMotDePasseType;
 use MonIndemnisationJustice\Forms\MotDePasseOublieType;
 use MonIndemnisationJustice\Repository\RequerantRepository;
-use MonIndemnisationJustice\Security\Authenticator\FranceConnectAuthenticator;
 use MonIndemnisationJustice\Security\Oidc\OidcClient;
 use MonIndemnisationJustice\Service\Mailer;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,7 +21,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\TooManyLoginAttemptsAuthenticationException;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -103,12 +102,13 @@ class SecurityController extends AbstractController
     }
 
     #[Route('/deconnexion/usager', name: 'securite_usager_deconnexion', methods: ['GET'])]
-    public function deconnexionFranceConnect(Request $request, TokenStorageInterface $tokenStorage, FranceConnectAuthenticator $authenticator): Response
+    public function deconnexionFranceConnect(Security $security): Response
     {
-        $authenticator->logout($request);
-        $tokenStorage->setToken(null);
+        if ($security->getUser()) {
+            $security->logout(false);
+        }
 
-        return $this->redirectToRoute('app_logout');
+        return $this->redirectToRoute('securite_connexion');
     }
 
     #[Route('/agent/connexion', name: 'agent_securite_connexion', methods: ['GET'])]


### PR DESCRIPTION
# 🔥  Capter les erreurs FranceConnect avec Sentry

Aujourd'hui lorsqu'une erreur survient à l'identification d'un usager via France Connect, celui-ci ne voit aucun message et rien n'est remonté dans Sentry.