### PR TITLE
Permettre de clôturer un dossier au motif qu'il est abandonné

### DIFF
--- a/backend/src/Api/Agent/Fip6/Endpoint/Dossier/CloturerDossierEndpoint.php
+++ b/backend/src/Api/Agent/Fip6/Endpoint/Dossier/CloturerDossierEndpoint.php
@@ -4,28 +4,25 @@ namespace MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Dossier;
 
 use MonIndemnisationJustice\Api\Agent\Fip6\Output\EtatDossierOutput;
 use MonIndemnisationJustice\Api\Agent\Fip6\Voter\DossierVoter;
+use MonIndemnisationJustice\Entity\Agent;
 use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\EtatDossierType;
-use MonIndemnisationJustice\Repository\AgentRepository;
 use MonIndemnisationJustice\Repository\DossierRepository;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
-use Symfony\Component\ObjectMapper\ObjectMapperInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
-#[Route('/api/agent/fip6/dossier/{id}/attribuer', name: 'api_agent_fip6_dossier_attribuer', methods: ['POST'])]
-#[IsGranted(DossierVoter::ACTION_ATTRIBUER, message: 'Seul un agent attributeur peut attribuer un dossier', statusCode: Response::HTTP_FORBIDDEN)]
-class AttribuerDossierEndpoint
+#[Route('/api/agent/fip6/dossier/{id}/cloturer', name: 'api_agent_fip6_dossier_cloturer', methods: ['POST'])]
+#[IsGranted(DossierVoter::ACTION_CLOTURER, 'dossier', message: 'Seul un agent autorisé peut clôturer un dossier', statusCode: Response::HTTP_FORBIDDEN)]
+class CloturerDossierEndpoint
 {
     public function __construct(
         protected readonly NormalizerInterface $normalizer,
-        protected readonly ObjectMapperInterface $objectMapper,
-        protected readonly AgentRepository $agentRepository,
         protected readonly DossierRepository $dossierRepository,
     ) {
     }
@@ -34,23 +31,19 @@ class AttribuerDossierEndpoint
         #[MapEntity]
         Dossier $dossier,
         #[MapRequestPayload]
-        AttribuerDossierInput $input,
+        CloturerDossierInput $cloture,
         Security $security,
     ) {
-        if (!$dossier->estAAttribuer()) {
-            return new JsonResponse(['erreur' => "Ce dossier n'est pas à attribuer"], Response::HTTP_BAD_REQUEST);
+        if (!$dossier->estCloturable()) {
+            return new JsonResponse(['erreur' => "Ce dossier n'est pas clôturable"], Response::HTTP_BAD_REQUEST);
         }
-        $agent = $this->agentRepository->find($input->redacteur_id);
+        /** @var Agent $agent */
+        $agent = $security->getUser();
 
-        if (!$agent->estRedacteur()) {
-            return new JsonResponse(['erreur' => "Cet agent n'est pas rédacteur"], Response::HTTP_BAD_REQUEST);
-        }
-
-        $dossier
-            ->setRedacteur($agent)
-            ->changerStatut(EtatDossierType::DOSSIER_A_INSTRUIRE, agent: $security->getUser(), contexte: [
-                'redacteur' => $agent->getId(),
-            ]);
+        $dossier->changerStatut(EtatDossierType::DOSSIER_CLOTURE, agent: $agent, contexte: [
+            'motif' => $cloture->motif,
+            'explication' => $cloture->explication,
+        ]);
         $this->dossierRepository->save($dossier);
 
         return new JsonResponse([

--- a/backend/src/Api/Agent/Fip6/Endpoint/Dossier/CloturerDossierInput.php
+++ b/backend/src/Api/Agent/Fip6/Endpoint/Dossier/CloturerDossierInput.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Dossier;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class CloturerDossierInput
+{
+    #[Assert\NotNull(message: 'Le motif de clôture est manquant')]
+    public string $motif;
+
+    #[Assert\NotNull(message: "L'explication de la clôture est manquant")]
+    public string $explication;
+}

--- a/backend/src/Api/Agent/Fip6/Endpoint/Dossier/DemarrerInstructionDossierEndpoint.php
+++ b/backend/src/Api/Agent/Fip6/Endpoint/Dossier/DemarrerInstructionDossierEndpoint.php
@@ -7,7 +7,7 @@ use MonIndemnisationJustice\Api\Agent\Fip6\Voter\DossierVoter;
 use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\EtatDossierType;
 use MonIndemnisationJustice\Repository\AgentRepository;
-use MonIndemnisationJustice\Repository\BrisPorteRepository;
+use MonIndemnisationJustice\Repository\DossierRepository;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -25,7 +25,7 @@ class DemarrerInstructionDossierEndpoint
         protected readonly NormalizerInterface $normalizer,
         protected readonly ObjectMapperInterface $objectMapper,
         protected readonly AgentRepository $agentRepository,
-        protected readonly BrisPorteRepository $dossierRepository,
+        protected readonly DossierRepository $dossierRepository,
     ) {
     }
 

--- a/backend/src/Api/Agent/Fip6/Voter/DossierVoter.php
+++ b/backend/src/Api/Agent/Fip6/Voter/DossierVoter.php
@@ -10,29 +10,28 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
 class DossierVoter extends Voter
 {
-    public const ACTION_ATTRIBUER = 'dossier:attribuer';
-    public const ACTION_INSTRUIRE = 'dossier:instruire';
+    public const string ACTION_ATTRIBUER = 'dossier:attribuer';
+    public const string ACTION_INSTRUIRE = 'dossier:instruire';
+    public const string ACTION_CLOTURER = 'dossier:cloturer';
+    public const string ACTION_AJOUTER_PIECE_JOINTE = 'dossier:ajouter-piece-jointe';
+    public const string ACTION_GENERER_DOCUMENT = 'dossier:generer-document';
 
-    public const ACTION_AJOUTER_PIECE_JOINTE = 'dossier:ajouter-piece-jointe';
-    public const ACTION_GENERER_DOCUMENT = 'dossier:generer-document';
-
-    public const ACTION_LISTER_A_CATEGORISER = 'dossier:lister:a-categoriser';
-    public const ACTION_LISTER_A_ATTRIBUER = 'dossier:lister:a-attribuer';
-    public const ACTION_LISTER_A_INSTRUIRE = 'dossier:lister:a-instruire';
-
-    public const ACTION_LISTER_REJET_A_SIGNER = 'dossier:lister:rejet-a-signer';
-    public const ACTION_LISTER_PROPOSITION_A_SIGNER = 'dossier:lister:proposition-a-signer';
-
-    public const ACTION_LISTER_A_VERIFIER = 'dossier:lister:a-verifier';
-    public const ACTION_LISTER_ARRETE_A_SIGNER = 'dossier:lister:arrete-a-signer';
-    public const ACTION_LISTER_A_TRANSMETTRE = 'dossier:lister:a-transmettre';
-    public const ACTION_LISTER_EN_ATTENTE_INDEMNISATION = 'dossier:lister:a-transmettre';
+    public const string ACTION_LISTER_A_CATEGORISER = 'dossier:lister:a-categoriser';
+    public const string ACTION_LISTER_A_ATTRIBUER = 'dossier:lister:a-attribuer';
+    public const string ACTION_LISTER_A_INSTRUIRE = 'dossier:lister:a-instruire';
+    public const string ACTION_LISTER_REJET_A_SIGNER = 'dossier:lister:rejet-a-signer';
+    public const string ACTION_LISTER_PROPOSITION_A_SIGNER = 'dossier:lister:proposition-a-signer';
+    public const string ACTION_LISTER_A_VERIFIER = 'dossier:lister:a-verifier';
+    public const string ACTION_LISTER_ARRETE_A_SIGNER = 'dossier:lister:arrete-a-signer';
+    public const string ACTION_LISTER_A_TRANSMETTRE = 'dossier:lister:a-transmettre';
+    public const string ACTION_LISTER_EN_ATTENTE_INDEMNISATION = 'dossier:lister:a-transmettre';
 
     protected function supports(string $attribute, mixed $subject): bool
     {
         return in_array($attribute, [
             self::ACTION_ATTRIBUER,
             self::ACTION_INSTRUIRE,
+            self::ACTION_CLOTURER,
             self::ACTION_AJOUTER_PIECE_JOINTE,
             self::ACTION_GENERER_DOCUMENT,
             self::ACTION_LISTER_A_CATEGORISER,
@@ -61,6 +60,7 @@ class DossierVoter extends Voter
             self::ACTION_AJOUTER_PIECE_JOINTE, => $this->agentPeutAjouterPieceJointe($agent, $subject),
             self::ACTION_ATTRIBUER => $this->agentPeutAttribuer($agent),
             self::ACTION_INSTRUIRE => $this->agentPeutInstruire($agent, $subject),
+            self::ACTION_CLOTURER => $this->agentPeutCloturer($agent, $subject),
             self::ACTION_GENERER_DOCUMENT, => $this->agentPeutGenererDocument($agent, $subject),
             self::ACTION_LISTER_A_CATEGORISER, self::ACTION_LISTER_A_ATTRIBUER, self::ACTION_LISTER_A_INSTRUIRE, self::ACTION_LISTER_REJET_A_SIGNER, self::ACTION_LISTER_PROPOSITION_A_SIGNER, self::ACTION_LISTER_A_VERIFIER, self::ACTION_LISTER_ARRETE_A_SIGNER, self::ACTION_LISTER_A_TRANSMETTRE, self::ACTION_LISTER_EN_ATTENTE_INDEMNISATION => $this->agentPeutLister($agent, $attribute),
             default => false,
@@ -80,6 +80,11 @@ class DossierVoter extends Voter
     protected function agentPeutInstruire(Agent $agent, Dossier $dossier): bool
     {
         return $agent->estRedacteur() && $agent->instruit($dossier);
+    }
+
+    protected function agentPeutCloturer(Agent $agent, Dossier $dossier): bool
+    {
+        return $agent->aRole(Agent::ROLE_AGENT_ATTRIBUTEUR) || $agent->aRole(Agent::ROLE_AGENT_VALIDATEUR) || $agent->instruit($dossier);
     }
 
     protected function agentPeutGenererDocument(Agent $agent, Dossier $dossier): bool

--- a/backend/src/Command/DossierEtatAvancerCommand.php
+++ b/backend/src/Command/DossierEtatAvancerCommand.php
@@ -10,7 +10,7 @@ use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\DossierType;
 use MonIndemnisationJustice\Entity\EtatDossierType;
 use MonIndemnisationJustice\Repository\AgentRepository;
-use MonIndemnisationJustice\Repository\BrisPorteRepository;
+use MonIndemnisationJustice\Repository\DossierRepository;
 use MonIndemnisationJustice\Service\DocumentManager;
 use MonIndemnisationJustice\Service\DossierManager;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class DossierEtatAvancerCommand extends Command
 {
     public function __construct(
-        protected readonly BrisPorteRepository $dossierRepository,
+        protected readonly DossierRepository $dossierRepository,
         protected readonly DossierManager $dossierManager,
         protected readonly AgentRepository $agentRepository,
         protected readonly DocumentManager $documentManager,

--- a/backend/src/Controller/Agent/DossierController.php
+++ b/backend/src/Controller/Agent/DossierController.php
@@ -15,7 +15,7 @@ use MonIndemnisationJustice\Entity\DocumentType;
 use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\EtatDossierType;
 use MonIndemnisationJustice\Repository\AgentRepository;
-use MonIndemnisationJustice\Repository\BrisPorteRepository;
+use MonIndemnisationJustice\Repository\DossierRepository;
 use MonIndemnisationJustice\Service\DocumentManager;
 use MonIndemnisationJustice\Service\DossierManager;
 use Psr\Log\LoggerInterface;
@@ -38,7 +38,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 class DossierController extends AgentController
 {
     public function __construct(
-        protected readonly BrisPorteRepository $dossierRepository,
+        protected readonly DossierRepository $dossierRepository,
         protected readonly AgentRepository $agentRepository,
         protected readonly DossierManager $dossierManager,
         protected readonly DocumentManager $documentManager,
@@ -94,27 +94,6 @@ class DossierController extends AgentController
                 ),
             ],
         ]);
-    }
-
-    // TODO créer un voter https://symfony.com/doc/current/security/voters.html
-    #[IsGranted(
-        attribute: new Expression('is_granted("ROLE_AGENT_ATTRIBUTEUR") or is_granted("ROLE_AGENT_VALIDATEUR") or user.instruit(subject["dossier"])'),
-        subject: [
-            'dossier' => new Expression('args["dossier"]'),
-        ]
-    )]
-    #[Route('/dossier/{id}/cloturer.json', name: 'agent_redacteur_marquer_doublon_papier_dossier', methods: ['POST'])]
-    public function cloturer(#[MapEntity(id: 'id')] Dossier $dossier, Request $request): Response
-    {
-        $dossier->changerStatut(EtatDossierType::DOSSIER_CLOTURE, agent: $this->getAgent(), contexte: [
-            'motif' => $request->getPayload()->get('motif'),
-            'explication' => $request->getPayload()->get('explication'),
-        ]);
-        $this->dossierRepository->save($dossier);
-
-        return new JsonResponse([
-            'etat' => $this->normalizer->normalize(EtatDossierOutput::depuisEtatDossier($dossier->getEtatDossier()), 'json'),
-        ], Response::HTTP_OK);
     }
 
     #[IsGranted(Agent::ROLE_AGENT_REDACTEUR)]

--- a/backend/src/Entity/BrisPorte.php
+++ b/backend/src/Entity/BrisPorte.php
@@ -4,12 +4,12 @@ namespace MonIndemnisationJustice\Entity;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
-use MonIndemnisationJustice\Repository\BrisPorteRepository;
+use MonIndemnisationJustice\Repository\DossierRepository;
 use Symfony\Component\Serializer\Attribute\Context;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Uid\Uuid;
 
-#[ORM\Entity(repositoryClass: BrisPorteRepository::class)]
+#[ORM\Entity(repositoryClass: DossierRepository::class)]
 #[ORM\Table(name: 'bris_porte')]
 class BrisPorte
 {

--- a/backend/src/Entity/Dossier.php
+++ b/backend/src/Entity/Dossier.php
@@ -8,9 +8,9 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Event\PrePersistEventArgs;
 use Doctrine\ORM\Mapping as ORM;
 use MonIndemnisationJustice\Event\Listener\DossierEntitylistener;
-use MonIndemnisationJustice\Repository\BrisPorteRepository;
+use MonIndemnisationJustice\Repository\DossierRepository;
 
-#[ORM\Entity(repositoryClass: BrisPorteRepository::class)]
+#[ORM\Entity(repositoryClass: DossierRepository::class)]
 #[ORM\HasLifecycleCallbacks]
 #[ORM\Table(name: 'dossiers')]
 #[ORM\EntityListeners([DossierEntitylistener::class])]
@@ -307,6 +307,11 @@ class Dossier
     public function estEditable(): bool
     {
         return $this->etatDossier->estEditable();
+    }
+
+    public function estCloturable(): bool
+    {
+        return $this->etatDossier->estCloturable();
     }
 
     public function estAAttribuer(): bool

--- a/backend/src/Entity/EtatDossier.php
+++ b/backend/src/Entity/EtatDossier.php
@@ -84,6 +84,11 @@ class EtatDossier
         return $this->etat->estEditable();
     }
 
+    public function estCloturable(): bool
+    {
+        return $this->etat->estCloturable();
+    }
+
     public function estAAttribuer(): bool
     {
         return $this->etat->estAAttribuer();

--- a/backend/src/Entity/EtatDossierType.php
+++ b/backend/src/Entity/EtatDossierType.php
@@ -120,9 +120,38 @@ enum EtatDossierType: string
         };
     }
 
+    /**
+     * Un dossier est clôturable s'il est déposé et non encore décidé ni terminé (ni clôturé ni refusé ni indemnisé).
+     */
+    public function estCloturable(): bool
+    {
+        return in_array(
+            $this,
+            [
+                self::DOSSIER_A_ATTRIBUER,
+                self::DOSSIER_A_INSTRUIRE,
+                self::DOSSIER_EN_INSTRUCTION,
+                self::DOSSIER_OK_A_SIGNER,
+                self::DOSSIER_KO_A_SIGNER]
+        );
+    }
+
+    /**
+     * Un dossier est éditable, par le requérant, s'il est en cours de constitution ou déposé, mais pas encore décidé.
+     */
     public function estEditable(): bool
     {
-        return in_array($this, [self::DOSSIER_A_FINALISER, self::DOSSIER_A_ATTRIBUER, self::DOSSIER_A_INSTRUIRE, self::DOSSIER_EN_INSTRUCTION, self::DOSSIER_OK_A_SIGNER, self::DOSSIER_KO_A_SIGNER]);
+        return in_array(
+            $this,
+            [
+                self::DOSSIER_A_FINALISER,
+                self::DOSSIER_A_ATTRIBUER,
+                self::DOSSIER_A_INSTRUIRE,
+                self::DOSSIER_EN_INSTRUCTION,
+                self::DOSSIER_OK_A_SIGNER,
+                self::DOSSIER_KO_A_SIGNER,
+            ]
+        );
     }
 
     public function estAAttribuer(): bool

--- a/backend/src/Event/Listener/DossierEntitylistener.php
+++ b/backend/src/Event/Listener/DossierEntitylistener.php
@@ -6,7 +6,7 @@ use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\EtatDossierType;
-use MonIndemnisationJustice\Repository\BrisPorteRepository;
+use MonIndemnisationJustice\Repository\DossierRepository;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 #[AsEntityListener(Dossier::class)]
@@ -14,7 +14,7 @@ class DossierEntitylistener
 {
     public function __construct(
         protected readonly EventDispatcherInterface $eventDispatcher,
-        protected readonly BrisPorteRepository $brisPorteRepository,
+        protected readonly DossierRepository $brisPorteRepository,
     ) {
     }
 

--- a/backend/src/Repository/DossierRepository.php
+++ b/backend/src/Repository/DossierRepository.php
@@ -19,7 +19,7 @@ use MonIndemnisationJustice\Entity\EtatDossierType;
  * @method Dossier[]    findAll()
  * @method Dossier[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
-class BrisPorteRepository extends ServiceEntityRepository
+class DossierRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
     {

--- a/backend/src/Service/DossierManager.php
+++ b/backend/src/Service/DossierManager.php
@@ -6,7 +6,7 @@ use MonIndemnisationJustice\Entity\Agent;
 use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\EtatDossierType;
 use MonIndemnisationJustice\Repository\AgentRepository;
-use MonIndemnisationJustice\Repository\BrisPorteRepository;
+use MonIndemnisationJustice\Repository\DossierRepository;
 
 /**
  * Service qui assure les opérations essentielles autour du dossier, notamment la gestion de l'état.
@@ -14,7 +14,7 @@ use MonIndemnisationJustice\Repository\BrisPorteRepository;
 class DossierManager
 {
     public function __construct(
-        protected readonly BrisPorteRepository $dossierRepository,
+        protected readonly DossierRepository $dossierRepository,
         protected readonly AgentRepository $agentRepository,
     ) {
     }

--- a/backend/templates/email/requerant/dossier_cloture.html.twig
+++ b/backend/templates/email/requerant/dossier_cloture.html.twig
@@ -14,13 +14,17 @@
         vient d'être clôturé par un agent pour la raison suivante :
     </p>
     <blockquote>
-        {{ dossier.explicationCloture }}
+        {{ dossier.explicationCloture|nl2br }}
     </blockquote>
     <br/>
     <p>
         Vous ne recevrez donc plus de notification concernant ce dossier. Si vous souhaitez contester cette décision,
         nous vous invitons à prendre contact auprès du bureau du précontentieux à l'adresse <a
                 href="mailto:{{ precontentieux_courriel_equipe }}">{{ precontentieux_courriel_equipe }}</a>.
+    </p>
+    <br/>
+    <p>
+        Veuillez ne pas répondre à cet e-mail. Les messages reçus à cette adresse ne sont pas lus et ne reçoivent donc aucune réponse.
     </p>
     <br/>
     Cordialement,<br/>

--- a/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/AjouterPieceJointeEndpointTest.php
+++ b/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/AjouterPieceJointeEndpointTest.php
@@ -7,6 +7,7 @@ use MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Dossier\AjouterPieceJointeEn
 use MonIndemnisationJustice\Entity\DocumentType;
 use MonIndemnisationJustice\Entity\EtatDossierType;
 use MonIndemnisationJustice\Tests\Api\Agent\Fip6\APIEndpointTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -17,9 +18,8 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  * attributeur d'ajouter une pièce jointe à un dossier.
  *
  * @internal
- *
- * @covers \MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Dossier\AjouterPieceJointeEndpoint
  */
+#[CoversClass(AjouterPieceJointeEndpoint::class)]
 class AjouterPieceJointeEndpointTest extends APIEndpointTestCase
 {
     protected KernelBrowser $client;

--- a/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/CloturerDossierEndpointTest.php
+++ b/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/CloturerDossierEndpointTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Api\Agent\Fip6\Dossier\Endpoint;
+
+use MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Dossier\CloturerDossierEndpoint;
+use MonIndemnisationJustice\Entity\EtatDossierType;
+use MonIndemnisationJustice\Tests\Api\Agent\Fip6\AbstractEndpointTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Teste le point d'entrée @CloturerDossierEndpoint de l'API, permettant d'attribuer un dossier à un rédacteur.
+ */
+#[CoversClass(CloturerDossierEndpoint::class)]
+class CloturerDossierEndpointTest extends AbstractEndpointTestCase
+{
+    /**
+     * ETQ agent attributeur, je dois pouvoir clôturer un dossier clôturable.
+     */
+    public function testClotureAttributeurOk(): void
+    {
+        $attributeur = $this->connexion('attributeur@justice.gouv.fr');
+        $dossier = $this->getDossierParEtat(EtatDossierType::DOSSIER_A_INSTRUIRE);
+
+        $this->client->request('POST', "/api/agent/fip6/dossier/{$dossier->getId()}/cloturer", [
+            'motif' => 'Dossier abandonné',
+            'explication' => 'Ce dossier est sans activité de votre part.',
+        ]);
+
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        /** @var \stdClass $output */
+        $output = json_decode($this->client->getResponse()->getContent(), false);
+
+        $this->assertObjectHasProperty('etat', $output);
+        $this->assertObjectHasProperty('etat', $output->etat);
+
+        $this->assertEquals(EtatDossierType::DOSSIER_CLOTURE->value, $output->etat->etat);
+        $this->assertEquals($attributeur->getId(), $output->etat->redacteur);
+    }
+
+    /**
+     * ETQ agent validateur, je dois pouvoir clôturer un dossier clôturable.
+     */
+    public function testClotureValidateurOk(): void
+    {
+        $validateur = $this->connexion('validateur@justice.gouv.fr');
+        $dossier = $this->getDossierParEtat(EtatDossierType::DOSSIER_A_INSTRUIRE);
+
+        $this->client->request('POST', "/api/agent/fip6/dossier/{$dossier->getId()}/cloturer", [
+            'motif' => 'Dossier abandonné',
+            'explication' => 'Ce dossier est sans activité de votre part.',
+        ]);
+
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        /** @var \stdClass $output */
+        $output = json_decode($this->client->getResponse()->getContent(), false);
+
+        $this->assertObjectHasProperty('etat', $output);
+        $this->assertObjectHasProperty('etat', $output->etat);
+
+        $this->assertEquals(EtatDossierType::DOSSIER_CLOTURE->value, $output->etat->etat);
+        $this->assertEquals($validateur->getId(), $output->etat->redacteur);
+    }
+
+    /**
+     * ETQ agent rédacteur, je dois pouvoir clôturer un dossier clôturable quen j'instruis.
+     */
+    public function testClotureRedacteurInstructeurOk(): void
+    {
+        $dossier = $this->getDossierParEtat(EtatDossierType::DOSSIER_A_INSTRUIRE);
+        $redacteur = $dossier->getRedacteur();
+        $this->client->loginUser($redacteur, 'agent');
+
+        $this->client->request('POST', "/api/agent/fip6/dossier/{$dossier->getId()}/cloturer", [
+            'motif' => 'Dossier abandonné',
+            'explication' => 'Ce dossier est sans activité de votre part.',
+        ]);
+
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        /** @var \stdClass $output */
+        $output = json_decode($this->client->getResponse()->getContent(), false);
+
+        $this->assertObjectHasProperty('etat', $output);
+        $this->assertObjectHasProperty('etat', $output->etat);
+
+        $this->assertEquals(EtatDossierType::DOSSIER_CLOTURE->value, $output->etat->etat);
+        $this->assertEquals($redacteur->getId(), $output->etat->redacteur);
+    }
+
+    /**
+     * ETQ agent rédacteur, je ne dois pas pouvoir clôturer un dossier clôturable que je n'instruis pas.
+     */
+    public function testClotureRedacteurNonInstructeurKo(): void
+    {
+        $dossier = $this->getDossierParEtat(EtatDossierType::DOSSIER_A_INSTRUIRE);
+        $redacteur = $this->connexion('reda.k-theur@justice.gouv.fr');
+        $this->assertNotEquals($redacteur->getId(), $dossier->getRedacteur()->getId());
+
+        $this->client->request('POST', "/api/agent/fip6/dossier/{$dossier->getId()}/cloturer", [
+            'motif' => 'Dossier abandonné',
+            'explication' => 'Ce dossier est sans activité de votre part.',
+        ]);
+
+        $this->assertEquals(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
+
+        /** @var \stdClass $output */
+        $output = json_decode($this->client->getResponse()->getContent(), false);
+
+        $this->assertObjectHasProperty('erreur', $output);
+        $this->assertEquals('Seul un agent autorisé peut clôturer un dossier', $output->erreur);
+    }
+
+    /**
+     * ETQ agent, je ne dois pas pouvoir clôturer un dossier qui n'est pas clôturable.
+     */
+    public function testClotureDossierNonCloturableKo(): void
+    {
+        $dossier = $this->getDossierParEtat(EtatDossierType::DOSSIER_A_FINALISER);
+        $validateur = $this->getAgent('validateur@justice.gouv.fr');
+        $this->client->loginUser($validateur, 'agent');
+
+        $this->client->request('POST', "/api/agent/fip6/dossier/{$dossier->getId()}/cloturer", [
+            'motif' => 'Dossier abandonné',
+            'explication' => 'Ce dossier est sans activité de votre part.',
+        ]);
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
+
+        /** @var \stdClass $output */
+        $output = json_decode($this->client->getResponse()->getContent(), false);
+
+        $this->assertObjectHasProperty('erreur', $output);
+        $this->assertEquals("Ce dossier n'est pas clôturable", $output->erreur);
+
+
+    }
+}

--- a/backend/tests/Repository/BrisPorteRepositoryTest.php
+++ b/backend/tests/Repository/BrisPorteRepositoryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MonIndemnisationJustice\Tests\Repository;
 
 use MonIndemnisationJustice\Entity\EtatDossierType;
-use MonIndemnisationJustice\Repository\BrisPorteRepository;
+use MonIndemnisationJustice\Repository\DossierRepository;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -21,8 +21,8 @@ class BrisPorteRepositoryTest extends WebTestCase
 
         $container = static::getContainer();
 
-        /** @var BrisPorteRepository $dossierRepository */
-        $dossierRepository = $container->get(BrisPorteRepository::class);
+        /** @var DossierRepository $dossierRepository */
+        $dossierRepository = $container->get(DossierRepository::class);
         $dossiersAAttribuer = $dossierRepository->listerDossierParEtat(EtatDossierType::DOSSIER_A_ATTRIBUER);
 
         $this->assertCount(1, $dossiersAAttribuer);

--- a/backend/tests/Service/DossierManagerTest.php
+++ b/backend/tests/Service/DossierManagerTest.php
@@ -5,7 +5,7 @@ namespace MonIndemnisationJustice\Tests\Service;
 use Doctrine\ORM\EntityManagerInterface;
 use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\EtatDossierType;
-use MonIndemnisationJustice\Repository\BrisPorteRepository;
+use MonIndemnisationJustice\Repository\DossierRepository;
 use MonIndemnisationJustice\Service\DossierManager;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -17,7 +17,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 class DossierManagerTest extends WebTestCase
 {
     protected EntityManagerInterface $em;
-    protected BrisPorteRepository $dossierRepository;
+    protected DossierRepository $dossierRepository;
     protected DossierManager $dossierManager;
 
     public function setUp(): void
@@ -27,7 +27,7 @@ class DossierManagerTest extends WebTestCase
         $container = static::getContainer();
 
         $this->em = $container->get(EntityManagerInterface::class);
-        $this->dossierRepository = $container->get(BrisPorteRepository::class);
+        $this->dossierRepository = $container->get(DossierRepository::class);
         $this->dossierManager = $container->get(DossierManager::class);
     }
 

--- a/frontend/src/apps/agent/fip6/dossiers/components/consultation/InfosDossier.tsx
+++ b/frontend/src/apps/agent/fip6/dossiers/components/consultation/InfosDossier.tsx
@@ -60,7 +60,7 @@ export const InfosDossier = ({
                 dossier.requerant.typePersonneMorale && (
                   <li>
                     Type de personne morale:{" "}
-                    <b>{dossier.requerant.typePersonneMorale}</b>)
+                    <b>{dossier.requerant.typePersonneMorale}</b>
                   </li>
                 )}
               <li>

--- a/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/CloturerAction.tsx
+++ b/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/CloturerAction.tsx
@@ -76,8 +76,8 @@ const RaisonsCloture: Map<string, RaisonCloture> = new Map<
       libelle: "Dossier abandonné",
       motif: "Doublon abandonné lors de l'instruction",
       explication: [
-        "Votre dossier de demande d'indemnisation est dans l'attente d'une ou plusieurs pièces complémentaires depuis au moins 30 jours.",
-        "Faute de retour de votre part, le dossier est désormais clos et ne recevra plus de mise à jour à l'avenir.",
+        "Votre dossier sur Mon Indemnisation Justice est sans activité depuis 30 jours et est désormais clôturé automatiquement.",
+        "Cela ne nécessite pas d'action de votre part.",
       ],
     } as RaisonCloture,
   ],

--- a/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/CloturerAction.tsx
+++ b/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/CloturerAction.tsx
@@ -1,14 +1,9 @@
+import { Agent, BaseDossier, DossierDetail, EtatDossier } from "@/common/models";
 import { ButtonProps } from "@codegouvfr/react-dsfr/Button";
-import { plainToInstance } from "class-transformer";
-import React, { ChangeEvent, useState } from "react";
-import {
-  Agent,
-  BaseDossier,
-  DossierDetail,
-  EtatDossier,
-} from "@/common/models";
 import { createModal } from "@codegouvfr/react-dsfr/Modal";
+import { plainToInstance } from "class-transformer";
 import { observer } from "mobx-react-lite";
+import React, { ChangeEvent, useState } from "react";
 
 const _modale = createModal({
   id: "modale-action-cloturer",
@@ -25,7 +20,7 @@ const cloturer = async ({
   explication: string;
 }): Promise<null | EtatDossier> => {
   const response = await fetch(
-    `/agent/redacteur/dossier/${dossier.id}/cloturer.json`,
+    `/api/agent/fip6/dossier/${dossier.id}/cloturer`,
     {
       method: "POST",
       headers: {
@@ -57,7 +52,7 @@ interface EtatCloture {
 interface RaisonCloture {
   libelle: string;
   motif: string;
-  explication: string;
+  explication: string | Array<string>;
 }
 
 const RaisonsCloture: Map<string, RaisonCloture> = new Map<
@@ -69,8 +64,21 @@ const RaisonsCloture: Map<string, RaisonCloture> = new Map<
     {
       libelle: "Doublon papier",
       motif: "Doublon d'un dossier déposé en version papier",
-      explication:
-        "Un exemplaire de ce dossier a déjà été déposé par voie postale auparavant. Le traitement continuera en dehors de la plateforme, si bien que le dossier initié en ligne est désormais clos et ne recevra plus de mise à jour à l'avenir.",
+      explication: [
+        "Un exemplaire de ce dossier a déjà été déposé par voie postale auparavant.",
+        "Le traitement continuera en dehors de la plateforme, si bien que le dossier initié en ligne est désormais clos et ne recevra plus de mise à jour à l'avenir.",
+      ],
+    } as RaisonCloture,
+  ],
+  [
+    "abandon-en-instruction",
+    {
+      libelle: "Dossier abandonné",
+      motif: "Doublon abandonné lors de l'instruction",
+      explication: [
+        "Votre dossier de demande d'indemnisation est dans l'attente d'une ou plusieurs pièces complémentaires depuis au moins 30 jours.",
+        "Faute de retour de votre part, le dossier est désormais clos et ne recevra plus de mise à jour à l'avenir.",
+      ],
     } as RaisonCloture,
   ],
   [
@@ -91,7 +99,7 @@ const estCloturable = ({
   agent: Agent;
 }) =>
   dossier.estCloturable() &&
-  (agent.estAttributeur() || agent.instruit(dossier));
+  (agent.estAttributeur() || agent.estValidateur() || agent.instruit(dossier));
 
 export const CloturerModale = observer(function CloturerActionModale({
   dossier,
@@ -110,7 +118,9 @@ export const CloturerModale = observer(function CloturerActionModale({
     setEtatCloture({
       ...etatCloture,
       motif: modele.motif,
-      explication: modele.explication,
+      explication: Array.isArray(modele.explication)
+        ? modele.explication.join("\n\n")
+        : modele.explication,
     } as EtatCloture);
 
   const setAction = (action?: ActionCloture) =>
@@ -156,7 +166,9 @@ export const CloturerModale = observer(function CloturerActionModale({
                 id="dossier-cloture-preselection"
                 defaultValue={""}
                 onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-                  selectionModele(RaisonsCloture.get(e.target.value))
+                  selectionModele(
+                    RaisonsCloture.get(e.target.value) as RaisonCloture,
+                  )
                 }
               >
                 <option value="" disabled hidden>
@@ -228,7 +240,11 @@ export const CloturerModale = observer(function CloturerActionModale({
                 <textarea
                   className="fr-input"
                   aria-describedby="dossier-cloture-explication-message"
-                  defaultValue={etatCloture.explication}
+                  defaultValue={
+                    Array.isArray(etatCloture.explication)
+                      ? etatCloture.explication
+                      : [etatCloture.explication].join("\n\n")
+                  }
                   disabled={etatCloture.action === "sauvegarde"}
                   onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
                     setEtatCloture({
@@ -237,7 +253,7 @@ export const CloturerModale = observer(function CloturerActionModale({
                     })
                   }
                   id="dossier-cloture-explication"
-                  rows={5}
+                  rows={10}
                 ></textarea>
                 {!etatCloture.explication && (
                   <div
@@ -304,9 +320,10 @@ export const CloturerModale = observer(function CloturerActionModale({
                     !etatCloture.explication ||
                     etatCloture.action === "sauvegarde"
                   }
-                  onClick={() =>
-                    valider(etatCloture.motif, etatCloture.explication)
-                  }
+                  onClick={async () => {
+                    if (etatCloture.motif && etatCloture.explication)
+                      await valider(etatCloture.motif, etatCloture.explication);
+                  }}
                 >
                   Valider la clôture
                 </button>


### PR DESCRIPTION
# Permettre de clôturer un dossier au motif qu'il est abandonné

[Des dossiers restent pendant des mois bloqués à l'instruction](https://trello.com/c/45oJ8zSU/337-nettoyage-des-dossiers-abandonn%C3%A9s-en-instruction), faute de retour du requérant pour des pièces manquantes (le plus souvent des attestations de non prise en charge par l'assurance ou le bailleur qui indiquent qu'il a, finalement, prise en charge).

Ici on ajoute un modèle de clôture, avec un motif (à usage interne) et une explication destinée au requérant, pour permettre de clôturer ces dossiers, y compris lors de l'instruction.

J'en profite pour déplacer l'action _backend_ de clôture vers l'API FIP6.