### PR TITLE
Bris porte/291 ajustements simples

### DIFF
--- a/backend/src/Service/MontantAfficheur.php
+++ b/backend/src/Service/MontantAfficheur.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace MonIndemnisationJustice\Service;
+
+class MontantAfficheur
+{
+    protected \NumberFormatter $formateur;
+
+    public function __construct()
+    {
+        $this->formateur = new \NumberFormatter('fr', \NumberFormatter::SPELLOUT);
+    }
+
+    public function afficherMontantLitteral(float $montant): string
+    {
+        if (round($montant) === $montant) {
+            return str_replace(['$montant', '$s'], [$this->formateur->format(round($montant)), $montant > 0 ? 's' : ''], '$montant euro$s');
+        }
+
+
+        $numberParsing = explode('.', number_format(round($montant, 2, PHP_ROUND_HALF_DOWN), 2, '.', ''));
+        $_1 = $this->formateur->format($numberParsing[0]);
+        $_2 = $this->formateur->format($numberParsing[1]);
+
+        return str_replace(['$1', '$2', '$3'], [$_1, $_2, $numberParsing[1] > 1 ? 's' : ''], '$1 euros et $2 centime$3');
+    }
+}

--- a/backend/src/Twig/AppRuntime.php
+++ b/backend/src/Twig/AppRuntime.php
@@ -5,6 +5,7 @@ namespace MonIndemnisationJustice\Twig;
 use Doctrine\ORM\EntityManagerInterface;
 use MonIndemnisationJustice\Entity\Usager;
 use MonIndemnisationJustice\Security\Authenticator\FranceConnectAuthenticator;
+use MonIndemnisationJustice\Service\MontantAfficheur;
 use Pentatrion\ViteBundle\Exception\EntrypointNotFoundException;
 use Pentatrion\ViteBundle\Service\EntrypointsLookup;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -27,6 +28,7 @@ class AppRuntime implements RuntimeExtensionInterface
         protected readonly FranceConnectAuthenticator $franceConnectAuthenticator,
         protected readonly FirewallMapInterface $firewallMap,
         protected readonly Security $security,
+        protected readonly MontantAfficheur $montantAfficheur,
     ) {
         $this->publicDirectory = "{$projectDirectory}/public";
     }
@@ -40,14 +42,10 @@ class AppRuntime implements RuntimeExtensionInterface
         return $this->router->generate('securite_usager_deconnexion');
     }
 
-    public function montantLitteral(float $amount, string $locale = 'fr'): string
+    public function montantLitteral(float $amount): string
     {
-        $t = new \NumberFormatter($locale, \NumberFormatter::SPELLOUT);
-        $numberParsing = explode('.', number_format(round($amount, 2, PHP_ROUND_HALF_DOWN), 2, '.', ''));
-        $_1 = $t->format($numberParsing[0]);
-        $_2 = $t->format($numberParsing[1]);
+        return $this->montantAfficheur->afficherMontantLitteral($amount);
 
-        return str_replace(['$1', '$2', '$3'], [$_1, $_2, $numberParsing[1] > 1 ? 's' : ''], '$1 euros et $2 centime$3');
     }
 
     public function estViteServerActif(): bool

--- a/backend/templates/courrier/_corps_introduction.html.twig
+++ b/backend/templates/courrier/_corps_introduction.html.twig
@@ -1,7 +1,6 @@
 <p>
     J’accuse réception de votre requête par laquelle vous
-    sollicitez{% if dossier.brisPorte.rapportAuLogement != 'AUTRE' or not dossier.brisPorte.precisionRapportAuLogement %}, en qualité de {{ dossier.brisPorte.rapportAuLogement != 'AUT' ? dossier.brisPorte.rapportAuLogement.libelle|lower : dossier.brisPorte.precisionRapportAuLogement|lower }},{% endif %}
-    l’indemnisation du préjudice subi en raison de la détérioration de la porte d’entrée du logement sis
+    sollicitez l’indemnisation du préjudice subi en raison de la détérioration de la porte d’entrée du logement sis
     {{ dossier.brisPorte.adresse.ligne1 }} à {{ dossier.brisPorte.adresse.localite|default }}
     ({{ dossier.brisPorte.adresse.codeDepartemental }}).
     Cette dégradation aurait été occasionnée au cours d’une opération de police

--- a/backend/templates/courrier/arretePaiement/_corps_arrete_paiement.html.twig
+++ b/backend/templates/courrier/arretePaiement/_corps_arrete_paiement.html.twig
@@ -9,7 +9,7 @@
 </p>
 <p>
     Vu la demande de {{ libelle }} aux fins d’indemnisation du préjudice subi en raison de la
-    détérioration de la porte d’entrée du logement situé à {{ dossier.brisPorte.adresse.localite|upper }}
+    détérioration de la porte d’entrée du logement situé {{ dossier.brisPorte.adresse.ligne1 }} à {{ dossier.brisPorte.adresse.localite|upper }}
     {% if dossier.brisPorte.adresse.codeDepartemental %}({{ dossier.brisPorte.adresse.codeDepartemental }}){% endif %} reçue
     le {{ dossier.dateDepot|format_datetime(locale='fr',pattern="d MMMM yyyy", timezone: 'Europe/Paris') }};
 </p>
@@ -30,8 +30,7 @@
 <p>
     Considérant que le préjudice matériel subi par {{ libelle }}, relatif à la détérioration de la
     porte d’entrée du logement sis {{ dossier.brisPorte.adresse.ligne1 }}
-    à {{ dossier.brisPorte.adresse.localite|default }} {% if dossier.brisPorte.adresse.codeDepartemental %}({{ dossier.brisPorte.adresse.codeDepartemental }}){% endif %}
-    ,
+    à {{ dossier.brisPorte.adresse.localite|default }} {% if dossier.brisPorte.adresse.codeDepartemental %}({{ dossier.brisPorte.adresse.codeDepartemental }}){% endif %},
     résulte d’une opération de police judiciaire menée
     le {{ dossier.brisPorte.dateOperation|format_datetime(locale='fr',pattern="d MMMM yyyy", timezone: 'Europe/Paris') }};
 </p>

--- a/backend/tests/Service/MontantAfficheurTest.php
+++ b/backend/tests/Service/MontantAfficheurTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Service;
+
+use MonIndemnisationJustice\Service\MontantAfficheur;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+#[CoversClass(MontantAfficheur::class)]
+class MontantAfficheurTest extends WebTestCase
+{
+    protected MontantAfficheur $montantAfficheur;
+
+    public function setUp(): void
+    {
+        self::bootKernel();
+
+        $container = static::getContainer();
+
+        $this->montantAfficheur = $container->get(MontantAfficheur::class);
+    }
+
+    public function testAfficherMontantLitteral(): void
+    {
+        $this->assertEquals('cent vingt-trois euros et dix-sept centimes', $this->montantAfficheur->afficherMontantLitteral(123.17));
+        $this->assertEquals('dix-huit euros', $this->montantAfficheur->afficherMontantLitteral(18.));
+        $this->assertEquals('zéro euro', $this->montantAfficheur->afficherMontantLitteral(0.));
+    }
+}

--- a/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/DeciderIndemnisationAction.tsx
+++ b/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/DeciderIndemnisationAction.tsx
@@ -231,6 +231,7 @@ export const DeciderIndemnisationModale = observer(
         title=" Accepter la demande d'indemnisation"
         iconId="fr-icon-checkbox-circle-line"
         size="large"
+        concealingBackdrop={false}
       >
         <Stepper
           currentStep={Etapes.rang(etape)}

--- a/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/DeciderRejetAction.tsx
+++ b/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/DeciderRejetAction.tsx
@@ -211,6 +211,7 @@ export const DeciderRejetModale = observer(function DeciderRejetModale({
       title=" Rejeter la demande d'indemnisation"
       iconId="fr-icon-close-circle-line"
       size="large"
+      concealingBackdrop={false}
     >
       <Stepper
         currentStep={Etapes.rang(etape)}

--- a/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/GenererArretePaiementAction.tsx
+++ b/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/GenererArretePaiementAction.tsx
@@ -129,6 +129,7 @@ export const GenererArretePaiementModale =
         title="Vérifier la déclaration d'acceptation"
         size="large"
         iconId="fr-icon-search-line"
+        concealingBackdrop={false}
       >
         {etatValidation.action === "verification" && (
           <>

--- a/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/SignerCourrierAction.tsx
+++ b/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/SignerCourrierAction.tsx
@@ -333,6 +333,7 @@ export const SignerCourrierModale = observer(function SignerCourrierModale({
           : "fr-icon-close-circle-line"
       }
       size="large"
+      concealingBackdrop={false}
     >
       <Stepper
         currentStep={rangEtape(dossier, etatSignature.etape)}


### PR DESCRIPTION
# Espace rédacteur : divers petits ajustements

Soient : 
- [x] Sur l'arrête de paiement, l'adresse du requérant / logement est manquante, ceci alors même que le requérant l'a rempli sur le dossier
- [x] Sur la DA, il y a un espace entre "Je soussigné(e)" et la virgule qui suit
- [x] Sur la PI ou la DA, le montant littéral de l'indemnisation finit par "zéro centime" si le montant est rond, ça ne fait pas très humain
- [x] Si je sélectionne une portion du texte avec la souris un peu trop fort au point de sortir de la modale, celle-ci se ferme et je perds l'accès à l'éditeur de texte
- [x] La mention "en qualité de " sur la PI / lettre de rejet est souvent incorrecte, mais de toute façon pas utilisée sur les anciennes trames donc on peut la retirer