### PR TITLE
Séparer les dossiers à instruire de ceux déjà en instruction sur les …

### DIFF
--- a/backend/src/Api/Agent/Fip6/Endpoint/Dossier/DecompterDossierEndpoint.php
+++ b/backend/src/Api/Agent/Fip6/Endpoint/Dossier/DecompterDossierEndpoint.php
@@ -40,6 +40,7 @@ class DecompterDossierEndpoint
 
         if ($agent->estRedacteur()) {
             $decomptes['a-instruire'] = $agent->nbDossiersAInstruire();
+            $decomptes['en-instruction'] = $agent->nbDossiersEnInstruction();
             $decomptes['a-verifier'] = $agent->nbDossiersAVerifier();
         }
 

--- a/backend/src/Api/Agent/Fip6/Endpoint/Dossier/ListerDossierEnInstructionEndpoint.php
+++ b/backend/src/Api/Agent/Fip6/Endpoint/Dossier/ListerDossierEnInstructionEndpoint.php
@@ -3,7 +3,7 @@
 namespace MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Dossier;
 
 use Doctrine\ORM\EntityManagerInterface;
-use MonIndemnisationJustice\Api\Agent\Fip6\Output\DossierAInstruireOutput;
+use MonIndemnisationJustice\Api\Agent\Fip6\Output\DossierEnInstructionOutput;
 use MonIndemnisationJustice\Api\Agent\Fip6\Voter\DossierVoter;
 use MonIndemnisationJustice\Entity\Agent;
 use MonIndemnisationJustice\Entity\Dossier;
@@ -15,11 +15,11 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * Route API qui retourne à un agent rédacteur la liste de ses dossiers à instruire.
+ * Route API qui retourne à un agent rédacteur la liste de ses dossiers en cours d'instruction.
  */
-#[Route('/api/agent/fip6/dossiers/liste/a-instruire', name: 'api_agent_dossiers_liste_a_instruire', methods: ['GET'])]
+#[Route('/api/agent/fip6/dossiers/liste/en-instruction', name: 'api_agent_dossiers_liste_en_instruction', methods: ['GET'])]
 #[IsGranted(DossierVoter::ACTION_LISTER_A_INSTRUIRE)]
-class ListerDossierAInstruireEndpoint
+class ListerDossierEnInstructionEndpoint
 {
     public function __construct(
         protected readonly EntityManagerInterface $entityManager,
@@ -35,8 +35,8 @@ class ListerDossierAInstruireEndpoint
         return new JsonResponse(
             $this->normalizer->normalize(
                 array_map(
-                    fn (Dossier $dossier) => DossierAInstruireOutput::creerDepuisDossier($dossier),
-                    array_values($agent->getDossiersAInstruire())
+                    fn (Dossier $dossier) => DossierEnInstructionOutput::creerDepuisDossier($dossier),
+                    array_values($agent->getDossiersEnInstruction())
                 ),
                 'json',
             )

--- a/backend/src/Api/Agent/Fip6/Output/DossierEnInstructionOutput.php
+++ b/backend/src/Api/Agent/Fip6/Output/DossierEnInstructionOutput.php
@@ -6,7 +6,7 @@ use MonIndemnisationJustice\Entity\Dossier;
 use Symfony\Component\Serializer\Attribute\Context;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
-class DossierAInstruireOutput
+class DossierEnInstructionOutput
 {
     public function __construct(
         public readonly int $id,
@@ -14,9 +14,11 @@ class DossierAInstruireOutput
         public readonly string $requerant,
         public readonly string $adresse,
         #[Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
-        public readonly \DateTimeInterface $dateOperation,
+        public readonly ?\DateTimeInterface $dateOperation,
         #[Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
         public readonly \DateTimeInterface $datePublication,
+        #[Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
+        public readonly \DateTimeInterface $dateDebutInstruction,
     ) {
     }
 
@@ -28,7 +30,8 @@ class DossierAInstruireOutput
             requerant: $dossier->getUsager()->getNomCourant(),
             adresse: $dossier->getBrisPorte()->getAdresse()->getLibelle(),
             dateOperation: $dossier->getBrisPorte()->getDateOperation(),
-            datePublication: $dossier->getDateDeclaration()
+            datePublication: $dossier->getDateDeclaration(),
+            dateDebutInstruction: $dossier->getEtatDossier()->getDate(),
         );
     }
 }

--- a/backend/src/Api/Agent/Fip6/Voter/DossierVoter.php
+++ b/backend/src/Api/Agent/Fip6/Voter/DossierVoter.php
@@ -22,6 +22,7 @@ class DossierVoter extends Voter
     public const string ACTION_LISTER_A_CATEGORISER = 'dossier:lister:a-categoriser';
     public const string ACTION_LISTER_A_ATTRIBUER = 'dossier:lister:a-attribuer';
     public const string ACTION_LISTER_A_INSTRUIRE = 'dossier:lister:a-instruire';
+    public const string ACTION_LISTER_EN_INSTRUCTION = 'dossier:lister:en-instruction';
     public const string ACTION_LISTER_REJET_A_SIGNER = 'dossier:lister:rejet-a-signer';
     public const string ACTION_LISTER_PROPOSITION_A_SIGNER = 'dossier:lister:proposition-a-signer';
     public const string ACTION_LISTER_A_VERIFIER = 'dossier:lister:a-verifier';
@@ -43,6 +44,7 @@ class DossierVoter extends Voter
             self::ACTION_LISTER_A_CATEGORISER,
             self::ACTION_LISTER_A_ATTRIBUER,
             self::ACTION_LISTER_A_INSTRUIRE,
+            self::ACTION_LISTER_EN_INSTRUCTION,
             self::ACTION_LISTER_REJET_A_SIGNER,
             self::ACTION_LISTER_PROPOSITION_A_SIGNER,
             self::ACTION_LISTER_ARRETE_A_SIGNER,
@@ -75,7 +77,7 @@ class DossierVoter extends Voter
             self::ACTION_INSTRUIRE => $this->agentPeutInstruire($agent, $subject),
             self::ACTION_CLOTURER => $this->agentPeutCloturer($agent, $subject),
             self::ACTION_GENERER_DOCUMENT, => $this->agentPeutGenererDocument($agent, $subject),
-            self::ACTION_LISTER_A_CATEGORISER, self::ACTION_LISTER_A_ATTRIBUER, self::ACTION_LISTER_A_INSTRUIRE, self::ACTION_LISTER_REJET_A_SIGNER, self::ACTION_LISTER_PROPOSITION_A_SIGNER, self::ACTION_LISTER_A_VERIFIER, self::ACTION_LISTER_ARRETE_A_SIGNER, self::ACTION_LISTER_A_TRANSMETTRE, self::ACTION_LISTER_EN_ATTENTE_INDEMNISATION => $this->agentPeutLister($agent, $attribute),
+            self::ACTION_LISTER_A_CATEGORISER, self::ACTION_LISTER_A_ATTRIBUER, self::ACTION_LISTER_A_INSTRUIRE, self::ACTION_LISTER_EN_INSTRUCTION, self::ACTION_LISTER_REJET_A_SIGNER, self::ACTION_LISTER_PROPOSITION_A_SIGNER, self::ACTION_LISTER_A_VERIFIER, self::ACTION_LISTER_ARRETE_A_SIGNER, self::ACTION_LISTER_A_TRANSMETTRE, self::ACTION_LISTER_EN_ATTENTE_INDEMNISATION => $this->agentPeutLister($agent, $attribute),
             default => false,
         };
     }
@@ -120,7 +122,7 @@ class DossierVoter extends Voter
         return match ($action) {
             self::ACTION_LISTER_A_CATEGORISER => $agent->aRole(Agent::ROLE_AGENT_BETAGOUV),
             self::ACTION_LISTER_A_ATTRIBUER => $agent->aRole(Agent::ROLE_AGENT_ATTRIBUTEUR),
-            self::ACTION_LISTER_A_INSTRUIRE, self::ACTION_LISTER_A_VERIFIER => $agent->aRole(Agent::ROLE_AGENT_REDACTEUR),
+            self::ACTION_LISTER_A_INSTRUIRE, self::ACTION_LISTER_EN_INSTRUCTION, self::ACTION_LISTER_A_VERIFIER => $agent->aRole(Agent::ROLE_AGENT_REDACTEUR),
             self::ACTION_LISTER_REJET_A_SIGNER, self::ACTION_LISTER_PROPOSITION_A_SIGNER, self::ACTION_LISTER_ARRETE_A_SIGNER => $agent->aRole(Agent::ROLE_AGENT_VALIDATEUR),
             self::ACTION_LISTER_A_TRANSMETTRE, self::ACTION_LISTER_EN_ATTENTE_INDEMNISATION => $agent->aRole(Agent::ROLE_AGENT_LIAISON_BUDGET),
             default => false,

--- a/backend/src/Entity/Agent.php
+++ b/backend/src/Entity/Agent.php
@@ -258,6 +258,14 @@ class Agent implements UserInterface
         return $this;
     }
 
+    /**
+     * @return Dossier[]
+     */
+    protected function getDossiersParEtatActuel(EtatDossierType $etatActuel): array
+    {
+        return $this->dossiers->filter(fn (Dossier $dossier) => $dossier->getEtatDossier()->getEtat() === $etatActuel)->toArray();
+    }
+
     public function nbDossiersAInstruire(): int
     {
         return count($this->getDossiersAInstruire());
@@ -268,7 +276,20 @@ class Agent implements UserInterface
      */
     public function getDossiersAInstruire(): array
     {
-        return $this->hasRole(Agent::ROLE_AGENT_REDACTEUR) ? $this->dossiers->filter(fn (Dossier $dossier) => in_array($dossier->getEtatDossier()->getEtat(), [EtatDossierType::DOSSIER_A_INSTRUIRE, EtatDossierType::DOSSIER_EN_INSTRUCTION]))->toArray() : [];
+        return $this->hasRole(Agent::ROLE_AGENT_REDACTEUR) ? $this->getDossiersParEtatActuel(EtatDossierType::DOSSIER_A_INSTRUIRE) : [];
+    }
+
+    public function nbDossiersEnInstruction(): int
+    {
+        return count($this->getDossiersEnInstruction());
+    }
+
+    /**
+     * @return Dossier[]
+     */
+    public function getDossiersEnInstruction(): array
+    {
+        return $this->hasRole(Agent::ROLE_AGENT_REDACTEUR) ? $this->getDossiersParEtatActuel(EtatDossierType::DOSSIER_EN_INSTRUCTION) : [];
     }
 
     public function nbDossiersAVerifier(): int
@@ -281,7 +302,7 @@ class Agent implements UserInterface
      */
     public function getDossiersAVerifier(): array
     {
-        return $this->hasRole(Agent::ROLE_AGENT_REDACTEUR) ? $this->dossiers->filter(fn (Dossier $dossier) => EtatDossierType::DOSSIER_OK_A_VERIFIER === $dossier->getEtatDossier()->getEtat())->toArray() : [];
+        return $this->hasRole(Agent::ROLE_AGENT_REDACTEUR) ? $this->getDossiersParEtatActuel(EtatDossierType::DOSSIER_OK_A_VERIFIER) : [];
     }
 
     /**

--- a/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/DecompterDossierEndpointTest.php
+++ b/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/DecompterDossierEndpointTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Api\Agent\Fip6\Dossier\Endpoint;
+
+use MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Dossier\DecompterDossierEndpoint;
+use MonIndemnisationJustice\Tests\Api\Agent\Fip6\AbstractEndpointTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(DecompterDossierEndpoint::class)]
+class DecompterDossierEndpointTest extends AbstractEndpointTestCase
+{
+    public function testDecompterDossierRedacteurOk()
+    {
+        $redacteur = $this->connexion('redacteur@justice.gouv.fr');
+
+        $this->client->request('GET', '/api/agent/fip6/decompter-dossiers');
+
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        /** @var array $output */
+        $donnees = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayEquals([
+            'a-instruire' => $redacteur->nbDossiersAInstruire(),
+            'en-instruction' => $redacteur->nbDossiersEnInstruction(),
+            'a-verifier' => $redacteur->nbDossiersAVerifier(),
+        ], $donnees);
+    }
+}

--- a/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/ListerDossierAInstruireEndpointTest.php
+++ b/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/ListerDossierAInstruireEndpointTest.php
@@ -25,7 +25,7 @@ class ListerDossierAInstruireEndpointTest extends APIEndpointTestCase
         /** @var array $output */
         $output = json_decode($this->client->getResponse()->getContent());
 
-        $this->assertCount(2, $output);
+        $this->assertCount(1, $output);
     }
 
     protected function getApiRoute(): string

--- a/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/ListerDossierEnInstructionEndpointTest.php
+++ b/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/ListerDossierEnInstructionEndpointTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MonIndemnisationJustice\Test\Api\Agent\Fip6\Dossier\Endpoint;
+
+use MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Dossier\ListerDossierEnInstructionEndpoint;
+use MonIndemnisationJustice\Tests\Api\Agent\Fip6\APIEndpointTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Teste le point d'entrée @ListerDossierEnInstructionEndpoint de l'API, listant les dossiers en cours d'instruction.
+ */
+#[CoversClass(ListerDossierEnInstructionEndpoint::class)]
+class ListerDossierEnInstructionEndpointTest extends APIEndpointTestCase
+{
+    /**
+     * ETQ rédacteur, je dois pouvoir charger la liste de mes dossiers en cours d'instruction.
+     */
+    public function testListeOk(): void
+    {
+        $this->connexion('redacteur@justice.gouv.fr');
+        $this->apiGet();
+
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        /** @var array $output */
+        $output = json_decode($this->client->getResponse()->getContent());
+
+        $this->assertCount(1, $output);
+    }
+
+    protected function getApiRoute(): string
+    {
+        return '/api/agent/fip6/dossiers/liste/en-instruction';
+    }
+}

--- a/end2end/tests/agent/fip6/lister-dossiers-en-intruction.e2e.test.ts
+++ b/end2end/tests/agent/fip6/lister-dossiers-en-intruction.e2e.test.ts
@@ -13,7 +13,7 @@ test("lister dossier à instruire", async ({browser}) => {
 
         await expect(getTitre(page, "Les dossiers")).toBeVisible();
 
-        await page.goto("/agent/fip6/dossiers/a-instruire");
+        await page.goto("/agent/fip6/dossiers/en-instruction");
 
         await expect(
             page.locator("H1", {hasText: "Dossiers à instruire"}),

--- a/frontend/src/apps/agent/fip6/composants/pages/RechercherDossierPage.tsx
+++ b/frontend/src/apps/agent/fip6/composants/pages/RechercherDossierPage.tsx
@@ -1,25 +1,21 @@
 import { BadgesDossier } from "@/apps/agent/fip6/dossiers/components/BadgesDossier.tsx";
 import { Route } from "@/apps/agent/fip6/routes/dossiers";
 import { Loader } from "@/common/composants/Loader.tsx";
-import {
-  Agent,
-  DossierApercu,
-  EtatDossierType,
-  Redacteur,
-} from "@/common/models";
+import { Agent, DossierApercu, EtatDossierType, Redacteur } from "@/common/models";
 import { dateEtHeureSimple, periode } from "@/common/services/date.ts";
 import { Accordion } from "@codegouvfr/react-dsfr/Accordion";
 import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import Pagination from "@codegouvfr/react-dsfr/Pagination";
 import { Select } from "@codegouvfr/react-dsfr/Select";
+import { RegisteredLinkProps } from "@codegouvfr/react-dsfr/src/link.tsx";
 import { useQuery } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { plainToInstance } from "class-transformer";
 import _ from "lodash";
 import React, { useMemo, useState } from "react";
 
-type RechercheRequete = {
+export type RechercheRequete = {
   etatsDossier: EtatDossierType[];
   attributaires: Redacteur[];
   inclureDossierNonAttribue: boolean;
@@ -70,14 +66,14 @@ export const validerParametres = (
  *
  * @returns Record<string, string>
  */
-const requeteVersParametres = (
+export const requeteVersParametres = (
   requete: RechercheRequete,
 ): Record<string, string> => {
   return Object.fromEntries(
     Object.entries({
-      p: requete.page.toString(),
+      p: requete.page?.toString(),
       a:
-        requete.attributaires.length > 0 || requete.inclureDossierNonAttribue
+        requete.attributaires?.length > 0 || requete.inclureDossierNonAttribue
           ? requete.attributaires
               .map((a) => a.id.toString())
               .concat(...(requete.inclureDossierNonAttribue ? ["_"] : []))
@@ -106,72 +102,42 @@ const requeteVersUrl = (requete: RechercheRequete): string => {
     .join("&");
 };
 
-export const RechercherRoute = () => {
+export const RechercherDossierPage = ({
+  agent,
+  redacteurs,
+  requete,
+  construireLien,
+  activerFiltreAttributaires = true,
+}: {
+  agent: Agent;
+  redacteurs: Redacteur[];
+  requete: RechercheRequete;
+  construireLien: ({
+    changement,
+  }: {
+    changement: Partial<RechercheRequete>;
+  }) => RegisteredLinkProps;
+  activerFiltreAttributaires?: boolean;
+}) => {
   // Fonction de navigation à partir de cette route
   const naviguer = useNavigate();
 
-  // Récupérer l'agent actuellement connecté
-  const { agent, redacteurs }: { agent: Agent; redacteurs: Redacteur[] } =
-    Route.useLoaderData();
-
-  // Récupérer les paramètres de recherche
-  const {
-    p,
-    a,
-    e,
-    r,
-  }: {
-    p: number;
-    a?: string;
-    e?: string;
-    r?: string;
-  } = Route.useSearch();
-
-  // L'état de la requête de recherche de dossiers, calculée à partir des paramères GET
-  const requete: RechercheRequete = useMemo<RechercheRequete>(() => {
-    const etats = e?.split("|");
-    const attributaires = a?.split("|").map((id) => parseInt(id));
-
-    return {
-      etatsDossier: etats
-        ? EtatDossierType.liste.filter((e) => etats.includes(e.slug))
-        : [
-            EtatDossierType.A_ATTRIBUER,
-            EtatDossierType.A_INSTRUIRE,
-            EtatDossierType.EN_INSTRUCTION,
-            EtatDossierType.OK_A_SIGNER,
-            EtatDossierType.OK_A_APPROUVER,
-            EtatDossierType.OK_A_VERIFIER,
-            EtatDossierType.OK_VERIFIE,
-            EtatDossierType.OK_A_INDEMNISER,
-            EtatDossierType.OK_EN_ATTENTE_PAIEMENT,
-            EtatDossierType.OK_INDEMNISE,
-            EtatDossierType.KO_A_SIGNER,
-            EtatDossierType.KO_REJETE,
-          ],
-      attributaires: attributaires
-        ? redacteurs.filter((redacteur: Redacteur) =>
-            attributaires.includes(redacteur.id),
-          )
-        : [],
-      inclureDossierNonAttribue: !!a?.split("|").find((v) => v === "_"),
-      recherche: r ?? "",
-      page: p,
-    };
-  }, [p, e, a, r]);
-
-  //
+  // Afficher les critères de recherche ou non
   const [afficherCriteres, setAfficherCriteres] = useState(false);
 
+  // Traduire la requête de recherche en paramètres d'URL
+  const urlParametres = useMemo(() => requeteVersUrl(requete), [requete]);
+
+  // Requête de récupération des dossiers
   const {
     isPending,
     error,
     data: reponse,
   } = useQuery<RechercheReponse>({
-    queryKey: ["recherche-dossiers", requeteVersUrl(requete)],
+    queryKey: ["recherche-dossiers", urlParametres],
     queryFn: async () => {
       const reponse = await fetch(
-        `/api/agent/fip6/dossiers/rechercher?${requeteVersUrl(requete)}`,
+        `/api/agent/fip6/dossiers/rechercher?${urlParametres}`,
       );
       const data = await reponse.json();
 
@@ -206,13 +172,13 @@ export const RechercherRoute = () => {
                     placeholder: "Paul, 75001 PARIS, GARNIER, ...",
                     defaultValue: requete.recherche,
                     onChange: _.debounce(async (e) => {
-                      await naviguer({
-                        to: Route.fullPath,
-                        search: requeteVersParametres({
-                          ...requete,
-                          recherche: e.target.value as string,
-                        }) as any,
-                      });
+                      await naviguer(
+                        construireLien({
+                          changement: {
+                            recherche: e.target.value as string,
+                          },
+                        }),
+                      );
                     }, 500),
                   }}
                 />
@@ -229,17 +195,17 @@ export const RechercherRoute = () => {
                     defaultValue: requete.etatsDossier.map((etat) => etat.slug),
 
                     onChange: async (event) => {
-                      await naviguer({
-                        to: Route.fullPath,
-                        search: requeteVersParametres({
-                          ...requete,
-                          etatsDossier: EtatDossierType.liste.filter((e) =>
-                            Array.from(event.target.selectedOptions)
-                              .map((option) => option.value)
-                              .includes(e.slug),
-                          ),
-                        }) as any,
-                      });
+                      await naviguer(
+                        construireLien({
+                          changement: {
+                            etatsDossier: EtatDossierType.liste.filter((e) =>
+                              Array.from(event.target.selectedOptions)
+                                .map((option) => option.value)
+                                .includes(e.slug),
+                            ),
+                          },
+                        }),
+                      );
                     },
                   }}
                 >
@@ -251,55 +217,61 @@ export const RechercherRoute = () => {
                 </Select>
               </div>
 
-              <div className="fr-col-4">
-                <Checkbox
-                  legend="Rédacteur attribué"
-                  hintText="&zwnj;"
-                  options={[
-                    {
-                      label: (
-                        <>
-                          Aucun <i className="fr-mx-1v">(non attribué)</i>
-                        </>
-                      ),
-                      nativeInputProps: {
-                        value: "",
-                        onChange: async (e) => {
-                          await naviguer({
-                            to: Route.fullPath,
-                            search: requeteVersParametres({
-                              ...requete,
-                              inclureDossierNonAttribue: e.target.checked,
-                            }) as any,
-                          });
+              {activerFiltreAttributaires && (
+                <div className="fr-col-4">
+                  <Checkbox
+                    legend="Rédacteur attribué"
+                    hintText="&zwnj;"
+                    options={[
+                      {
+                        label: (
+                          <>
+                            Aucun <i className="fr-mx-1v">(non attribué)</i>
+                          </>
+                        ),
+                        nativeInputProps: {
+                          value: "",
+                          onChange: async (e) => {
+                            await naviguer(
+                              construireLien({
+                                changement: {
+                                  inclureDossierNonAttribue: e.target.checked,
+                                },
+                              }),
+                            );
+                          },
+                          checked: requete.inclureDossierNonAttribue,
                         },
-                        checked: requete.inclureDossierNonAttribue,
                       },
-                    },
-                    ...(redacteurs || []).map((redacteur) => ({
-                      label:
-                        agent.id === redacteur.id ? <b>Moi</b> : redacteur.nom,
-                      nativeInputProps: {
-                        onChange: async (e) => {
-                          await naviguer({
-                            to: Route.fullPath,
-                            search: requeteVersParametres({
-                              ...requete,
-                              attributaires: requete.attributaires
-                                .filter((a) => a.id !== redacteur.id)
-                                .concat(
-                                  ...(e.target.checked ? [redacteur] : []),
-                                ),
-                            }) as any,
-                          });
+                      ...(redacteurs || []).map((redacteur) => ({
+                        label:
+                          agent.id === redacteur.id ? (
+                            <b>Moi</b>
+                          ) : (
+                            redacteur.nom
+                          ),
+                        nativeInputProps: {
+                          onChange: async (e) => {
+                            await naviguer(
+                              construireLien({
+                                changement: {
+                                  attributaires: requete.attributaires
+                                    .filter((a) => a.id !== redacteur.id)
+                                    .concat(
+                                      ...(e.target.checked ? [redacteur] : []),
+                                    ),
+                                },
+                              }),
+                            );
+                          },
+                          checked: requete.attributaires.includes(redacteur),
                         },
-                        checked: requete.attributaires.includes(redacteur),
-                      },
-                    })),
-                  ]}
-                  state="default"
-                />
-              </div>
+                      })),
+                    ]}
+                    state="default"
+                  />
+                </div>
+              )}
             </div>
           </Accordion>
 
@@ -325,11 +297,10 @@ export const RechercherRoute = () => {
                     defaultPage={requete.page}
                     showFirstLast={true}
                     getPageLinkProps={(pageNumber: number) => ({
-                      from: Route.fullPath,
-                      to: Route.fullPath,
-                      search: requeteVersParametres({
-                        ...requete,
-                        page: pageNumber,
+                      ...construireLien({
+                        changement: {
+                          page: pageNumber,
+                        },
                       }),
                       "aria-current":
                         requete.page === pageNumber ? "true" : undefined,
@@ -475,11 +446,10 @@ export const RechercherRoute = () => {
                     defaultPage={requete.page}
                     showFirstLast={true}
                     getPageLinkProps={(pageNumber: number) => ({
-                      from: Route.fullPath,
-                      to: Route.fullPath,
-                      search: requeteVersParametres({
-                        ...requete,
-                        page: pageNumber,
+                      ...construireLien({
+                        changement: {
+                          page: pageNumber,
+                        },
                       }),
                       "aria-current":
                         requete.page === pageNumber ? "true" : undefined,

--- a/frontend/src/apps/agent/fip6/composants/routes/RechercherRoute.tsx
+++ b/frontend/src/apps/agent/fip6/composants/routes/RechercherRoute.tsx
@@ -1,0 +1,498 @@
+import { BadgesDossier } from "@/apps/agent/fip6/dossiers/components/BadgesDossier.tsx";
+import { Route } from "@/apps/agent/fip6/routes/dossiers";
+import { Loader } from "@/common/composants/Loader.tsx";
+import {
+  Agent,
+  DossierApercu,
+  EtatDossierType,
+  Redacteur,
+} from "@/common/models";
+import { dateEtHeureSimple, periode } from "@/common/services/date.ts";
+import { Accordion } from "@codegouvfr/react-dsfr/Accordion";
+import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import Pagination from "@codegouvfr/react-dsfr/Pagination";
+import { Select } from "@codegouvfr/react-dsfr/Select";
+import { useQuery } from "@tanstack/react-query";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { plainToInstance } from "class-transformer";
+import _ from "lodash";
+import React, { useMemo, useState } from "react";
+
+type RechercheRequete = {
+  etatsDossier: EtatDossierType[];
+  attributaires: Redacteur[];
+  inclureDossierNonAttribue: boolean;
+  // Recherche textuelle libre
+  recherche: string;
+  page: number;
+};
+
+type RechercheReponse = {
+  resultats: DossierApercu[];
+  taille: number;
+  total: number;
+  page: number;
+};
+
+export const validerParametres = (
+  search: Record<string, string | string[] | undefined>,
+) => {
+  return {
+    p: search.p ? parseInt(search.p as string) : 1,
+    a: search.a?.toString(),
+    e:
+      search.e ||
+      [
+        EtatDossierType.A_ATTRIBUER,
+        EtatDossierType.A_INSTRUIRE,
+        EtatDossierType.EN_INSTRUCTION,
+        EtatDossierType.OK_A_SIGNER,
+        EtatDossierType.OK_A_APPROUVER,
+        EtatDossierType.OK_A_VERIFIER,
+        EtatDossierType.OK_VERIFIE,
+        EtatDossierType.OK_A_INDEMNISER,
+        EtatDossierType.OK_EN_ATTENTE_PAIEMENT,
+        EtatDossierType.OK_INDEMNISE,
+        EtatDossierType.KO_A_SIGNER,
+        EtatDossierType.KO_REJETE,
+      ]
+        .map((e) => e.slug)
+        .join("|"),
+    r: search.r,
+  };
+};
+
+/**
+ * Convertit une requête de recherche en paramètres d'URL, en excluant les valeurs non définies.
+ *
+ * @param requete RechercheRequete
+ *
+ * @returns Record<string, string>
+ */
+const requeteVersParametres = (
+  requete: RechercheRequete,
+): Record<string, string> => {
+  return Object.fromEntries(
+    Object.entries({
+      p: requete.page.toString(),
+      a:
+        requete.attributaires.length > 0 || requete.inclureDossierNonAttribue
+          ? requete.attributaires
+              .map((a) => a.id.toString())
+              .concat(...(requete.inclureDossierNonAttribue ? ["_"] : []))
+              .join("|")
+          : undefined,
+      e: requete.etatsDossier.length
+        ? requete.etatsDossier.map((e: EtatDossierType) => e.slug).join("|")
+        : undefined,
+      r: !!requete.recherche ? requete.recherche : undefined,
+    })
+      .filter(([_, value]) => typeof value === "string")
+      .map(([key, value]) => [key, value as string]),
+  );
+};
+
+/**
+ * Convertit une requête de recherche en requête GET.
+ *
+ * @param requete RechercheRequete
+ *
+ * @returns string
+ */
+const requeteVersUrl = (requete: RechercheRequete): string => {
+  return Object.entries(requeteVersParametres(requete))
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+};
+
+export const RechercherRoute = () => {
+  // Fonction de navigation à partir de cette route
+  const naviguer = useNavigate();
+
+  // Récupérer l'agent actuellement connecté
+  const { agent, redacteurs }: { agent: Agent; redacteurs: Redacteur[] } =
+    Route.useLoaderData();
+
+  // Récupérer les paramètres de recherche
+  const {
+    p,
+    a,
+    e,
+    r,
+  }: {
+    p: number;
+    a?: string;
+    e?: string;
+    r?: string;
+  } = Route.useSearch();
+
+  // L'état de la requête de recherche de dossiers, calculée à partir des paramères GET
+  const requete: RechercheRequete = useMemo<RechercheRequete>(() => {
+    const etats = e?.split("|");
+    const attributaires = a?.split("|").map((id) => parseInt(id));
+
+    return {
+      etatsDossier: etats
+        ? EtatDossierType.liste.filter((e) => etats.includes(e.slug))
+        : [
+            EtatDossierType.A_ATTRIBUER,
+            EtatDossierType.A_INSTRUIRE,
+            EtatDossierType.EN_INSTRUCTION,
+            EtatDossierType.OK_A_SIGNER,
+            EtatDossierType.OK_A_APPROUVER,
+            EtatDossierType.OK_A_VERIFIER,
+            EtatDossierType.OK_VERIFIE,
+            EtatDossierType.OK_A_INDEMNISER,
+            EtatDossierType.OK_EN_ATTENTE_PAIEMENT,
+            EtatDossierType.OK_INDEMNISE,
+            EtatDossierType.KO_A_SIGNER,
+            EtatDossierType.KO_REJETE,
+          ],
+      attributaires: attributaires
+        ? redacteurs.filter((redacteur: Redacteur) =>
+            attributaires.includes(redacteur.id),
+          )
+        : [],
+      inclureDossierNonAttribue: !!a?.split("|").find((v) => v === "_"),
+      recherche: r ?? "",
+      page: p,
+    };
+  }, [p, e, a, r]);
+
+  //
+  const [afficherCriteres, setAfficherCriteres] = useState(false);
+
+  const {
+    isPending,
+    error,
+    data: reponse,
+  } = useQuery<RechercheReponse>({
+    queryKey: ["recherche-dossiers", requeteVersUrl(requete)],
+    queryFn: async () => {
+      const reponse = await fetch(
+        `/api/agent/fip6/dossiers/rechercher?${requeteVersUrl(requete)}`,
+      );
+      const data = await reponse.json();
+
+      return {
+        resultats: plainToInstance(DossierApercu, data.resultats as any[]),
+        taille: data.taille,
+        total: data.total,
+        page: data.page,
+      } as RechercheReponse;
+    },
+  });
+
+  return (
+    <div className="fr-container fr-container--fluid fr-my-3w">
+      <div className="fr-grid-row">
+        <div className="fr-col-12">
+          <h1>Les dossiers</h1>
+
+          <Accordion
+            label="Critères de recherche"
+            expanded={afficherCriteres}
+            onExpandedChange={(afficher) => setAfficherCriteres(afficher)}
+          >
+            <div className="fr-grid-row fr-grid-row--gutters">
+              <div className="fr-col-4">
+                <Input
+                  label="Filtre"
+                  hintText="Nom, prénom du requérant, adresse, etc..."
+                  state="default"
+                  nativeInputProps={{
+                    type: "search",
+                    placeholder: "Paul, 75001 PARIS, GARNIER, ...",
+                    defaultValue: requete.recherche,
+                    onChange: _.debounce(async (e) => {
+                      await naviguer({
+                        to: Route.fullPath,
+                        search: requeteVersParametres({
+                          ...requete,
+                          recherche: e.target.value as string,
+                        }) as any,
+                      });
+                    }, 500),
+                  }}
+                />
+              </div>
+
+              <div className="fr-col-4" style={{ justifySelf: "stretch" }}>
+                <Select
+                  label="Statut du dossier"
+                  hint="&zwnj;"
+                  style={{ height: "100%" }}
+                  nativeSelectProps={{
+                    multiple: true,
+                    size: EtatDossierType.liste.length,
+                    defaultValue: requete.etatsDossier.map((etat) => etat.slug),
+
+                    onChange: async (event) => {
+                      await naviguer({
+                        to: Route.fullPath,
+                        search: requeteVersParametres({
+                          ...requete,
+                          etatsDossier: EtatDossierType.liste.filter((e) =>
+                            Array.from(event.target.selectedOptions)
+                              .map((option) => option.value)
+                              .includes(e.slug),
+                          ),
+                        }) as any,
+                      });
+                    },
+                  }}
+                >
+                  {EtatDossierType.liste.map((etat) => (
+                    <option value={etat.slug} key={etat.id}>
+                      {etat.libelle}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+
+              <div className="fr-col-4">
+                <Checkbox
+                  legend="Rédacteur attribué"
+                  hintText="&zwnj;"
+                  options={[
+                    {
+                      label: (
+                        <>
+                          Aucun <i className="fr-mx-1v">(non attribué)</i>
+                        </>
+                      ),
+                      nativeInputProps: {
+                        value: "",
+                        onChange: async (e) => {
+                          await naviguer({
+                            to: Route.fullPath,
+                            search: requeteVersParametres({
+                              ...requete,
+                              inclureDossierNonAttribue: e.target.checked,
+                            }) as any,
+                          });
+                        },
+                        checked: requete.inclureDossierNonAttribue,
+                      },
+                    },
+                    ...(redacteurs || []).map((redacteur) => ({
+                      label:
+                        agent.id === redacteur.id ? <b>Moi</b> : redacteur.nom,
+                      nativeInputProps: {
+                        onChange: async (e) => {
+                          await naviguer({
+                            to: Route.fullPath,
+                            search: requeteVersParametres({
+                              ...requete,
+                              attributaires: requete.attributaires
+                                .filter((a) => a.id !== redacteur.id)
+                                .concat(
+                                  ...(e.target.checked ? [redacteur] : []),
+                                ),
+                            }) as any,
+                          });
+                        },
+                        checked: requete.attributaires.includes(redacteur),
+                      },
+                    })),
+                  ]}
+                  state="default"
+                />
+              </div>
+            </div>
+          </Accordion>
+
+          {reponse ? (
+            <div className="fr-grid-row">
+              <div className="fr-col-12 fr-my-2w">
+                <h6 className="fr-m-0">
+                  {isPending ? (
+                    "Chargement des dosssiers ..."
+                  ) : (
+                    <>
+                      {reponse.total} dossier
+                      {reponse.total > 1 && "s"} trouvé
+                      {reponse.total > 1 && "s"}
+                    </>
+                  )}
+                </h6>
+              </div>
+              {!isPending && (
+                <div className="fr-col-12">
+                  <Pagination
+                    count={Math.ceil((1 * reponse.total) / reponse.taille)}
+                    defaultPage={requete.page}
+                    showFirstLast={true}
+                    getPageLinkProps={(pageNumber: number) => ({
+                      from: Route.fullPath,
+                      to: Route.fullPath,
+                      search: requeteVersParametres({
+                        ...requete,
+                        page: pageNumber,
+                      }),
+                      "aria-current":
+                        requete.page === pageNumber ? "true" : undefined,
+                    })}
+                  />
+                </div>
+              )}
+              <div className="fr-col-12 fr-my-1w">
+                <div className="fr-table fr-m-0">
+                  {isPending ? (
+                    <Loader />
+                  ) : (
+                    <div className="fr-table__wrapper">
+                      <div className="fr-table__container">
+                        <div className="fr-table__content">
+                          <table data-testid="tableau-dossiers-resultats">
+                            <thead>
+                              <tr>
+                                <th scope="col" className="fr-col-2">
+                                  Référence / état
+                                </th>
+                                <th scope="col" className="fr-col-4">
+                                  Idéntité et adresse du requérant
+                                </th>
+                                <th scope="col" className="fr-col-3">
+                                  Déposé le
+                                </th>
+                                <th scope="col" className="fr-col-2">
+                                  Attribué à
+                                </th>
+                                <th scope="col" className="fr-col-1">
+                                  <span className="fr-hidden">Action</span>
+                                </th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {reponse.resultats.length > 0 ? (
+                                reponse.resultats.map(
+                                  (dossier: DossierApercu) => (
+                                    <tr key={dossier.id}>
+                                      <td className="fr-col-2">
+                                        <span className="fr-text--lg fr-text--bold">
+                                          {dossier.reference}
+                                        </span>
+                                        <br />
+                                        <p
+                                          className={`fr-badge fr-badge--no-icon fr-badge--dossier-etat fr-badge--dossier-etat--${dossier.etat.etat.slug} fr-mb-1v`}
+                                          {...(dossier.etat.estCloture()
+                                            ? {
+                                                "aria-describedby": `tooltip-etat-dossier-${dossier.id}`,
+                                              }
+                                            : {})}
+                                        >
+                                          {dossier.etat.libelle}
+                                        </p>
+                                        {dossier.etat.estCloture() && (
+                                          <span
+                                            className="fr-tooltip fr-placement"
+                                            id={`tooltip-etat-dossier-${dossier.id}`}
+                                            role="tooltip"
+                                          >
+                                            {dossier.etat.contexte
+                                              ?.motifRejet || (
+                                              <i>Aucun motif</i>
+                                            )}
+                                          </span>
+                                        )}
+                                        <br />
+                                        depuis{" "}
+                                        {periode(dossier.etat.dateEntree)}
+                                      </td>
+                                      <td
+                                        className="fr-col-4"
+                                        style={{
+                                          wordWrap: "break-word",
+                                          whiteSpace: "pre-wrap",
+                                        }}
+                                      >
+                                        <span className="fr-text--lg fr-text--bold">
+                                          {dossier.requerant}
+                                        </span>
+                                        <br />
+                                        <p>{dossier.adresse}</p>
+                                      </td>
+                                      <td
+                                        className="fr-col-2"
+                                        style={{ overflow: "hidden" }}
+                                      >
+                                        {dossier.dateDepot && (
+                                          <>
+                                            {dateEtHeureSimple(
+                                              dossier.dateDepot,
+                                              { masquerAnneeSiCourante: true },
+                                            )}
+                                          </>
+                                        )}
+                                        <BadgesDossier dossier={dossier} />
+                                      </td>
+                                      <td className="fr-col-2">
+                                        {dossier.redacteur ? (
+                                          <span className="fr-text--bold">
+                                            {dossier.redacteur.nom}
+                                          </span>
+                                        ) : (
+                                          <i>non attribué</i>
+                                        )}
+                                      </td>
+
+                                      <td className="fr-col-1">
+                                        <div className="fr-btns-group fr-btns-group--right">
+                                          <Link
+                                            className="fr-btn fr-btn--tertiary fr-icon-eye-line fr-btn--sm"
+                                            from={Route.fullPath}
+                                            to={"/dossier/$id"}
+                                            params={{ id: dossier.id }}
+                                          ></Link>
+                                        </div>
+                                      </td>
+                                    </tr>
+                                  ),
+                                )
+                              ) : (
+                                <tr>
+                                  <td colSpan={5}>
+                                    <p className="fr-p-2w">
+                                      Aucun dossier correspondant
+                                    </p>
+                                  </td>
+                                </tr>
+                              )}
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+              {!isPending && (
+                <div className="fr-col-12 fr-mt-2w">
+                  <Pagination
+                    count={Math.ceil((1 * reponse.total) / reponse.taille)}
+                    defaultPage={requete.page}
+                    showFirstLast={true}
+                    getPageLinkProps={(pageNumber: number) => ({
+                      from: Route.fullPath,
+                      to: Route.fullPath,
+                      search: requeteVersParametres({
+                        ...requete,
+                        page: pageNumber,
+                      }),
+                      "aria-current":
+                        requete.page === pageNumber ? "true" : undefined,
+                    })}
+                  />
+                </div>
+              )}
+            </div>
+          ) : (
+            <Loader />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/apps/agent/fip6/dossiers/components/consultation/piecejointe/TelechargerPieceJointe.tsx
+++ b/frontend/src/apps/agent/fip6/dossiers/components/consultation/piecejointe/TelechargerPieceJointe.tsx
@@ -15,7 +15,8 @@ const component = function TelechargerPieceJointe({
       details={pieceJointe?.infoFichier}
       label={pieceJointe.originalFilename}
       linkProps={{
-        href: pieceJointe.url,
+        href: `${window.location.origin}${pieceJointe.url}`,
+        target: "_self",
       }}
     />
   );

--- a/frontend/src/apps/agent/fip6/modeles/dossier.ts
+++ b/frontend/src/apps/agent/fip6/modeles/dossier.ts
@@ -1,0 +1,19 @@
+import DateTransform from "@/common/normalisation/transformers/DateTransform.ts";
+import "reflect-metadata";
+
+export class DossierAInstruire {
+  readonly id: number;
+  readonly reference: string;
+  readonly requerant: string;
+  readonly adresse: string;
+  @DateTransform(true)
+  readonly dateOperation?: Date;
+  @DateTransform(true)
+  readonly datePublication: Date;
+  readonly estEligible: boolean;
+}
+
+export class DossierEnInstruction extends DossierAInstruire {
+  @DateTransform(true)
+  readonly dateDebutInstruction: Date;
+}

--- a/frontend/src/apps/agent/fip6/modeles/index.ts
+++ b/frontend/src/apps/agent/fip6/modeles/index.ts
@@ -1,0 +1,5 @@
+import {
+  DossierAInstruire,DossierEnInstruction
+} from "./dossier";
+
+export { DossierAInstruire, DossierEnInstruction };

--- a/frontend/src/apps/agent/fip6/routes/__root.tsx
+++ b/frontend/src/apps/agent/fip6/routes/__root.tsx
@@ -130,7 +130,7 @@ const EspaceRedacteur = () => {
                 },
               ]
             : []),
-          // Liste des dossiers à instruire (si REDACTEUR)
+          // Liste des dossiers en instruction / à instruire (si REDACTEUR)
           ...(agent.aRole(RoleAgent.REDACTEUR)
             ? [
                 {
@@ -147,6 +147,22 @@ const EspaceRedacteur = () => {
                   ),
                   linkProps: {
                     to: "/dossiers/a-instruire",
+                  },
+                },
+                {
+                  text: (
+                    <>
+                      En cours d'instruction
+                      <Badge
+                        as={"p"}
+                        small={true}
+                        className={"fr-badge--blue-ecume"}
+                        children={compteurDossiers["en-instruction"]}
+                      />
+                    </>
+                  ),
+                  linkProps: {
+                    to: "/dossiers/en-instruction",
                   },
                 },
               ]

--- a/frontend/src/apps/agent/fip6/routes/__root.tsx
+++ b/frontend/src/apps/agent/fip6/routes/__root.tsx
@@ -57,6 +57,15 @@ const EspaceRedacteur = () => {
 
     const liens: NavItem[] = [];
 
+    if (agent.aRole(RoleAgent.REDACTEUR)) {
+      liens.push({
+        text: <>Mes dossiers</>,
+        linkProps: {
+          to: "/dossiers/mes-dossiers",
+        },
+      });
+    }
+
     if (agent.aRole(RoleAgent.DOSSIER)) {
       liens.push({
         text: (

--- a/frontend/src/apps/agent/fip6/routes/__root.tsx
+++ b/frontend/src/apps/agent/fip6/routes/__root.tsx
@@ -1,12 +1,21 @@
 import { AgentContext } from "@/apps/agent/_commun/contexts/AgentContext.ts";
 import { container } from "@/apps/agent/fip6/container.ts";
-import { CompteurDossiers, DossierManagerInterface } from "@/apps/agent/fip6/services/dossier.ts";
+import {
+  CompteurDossiers,
+  DossierManagerInterface,
+} from "@/apps/agent/fip6/services/dossier.ts";
 import { RoleAgent } from "@/common/models/Agent.ts";
 import Badge from "@codegouvfr/react-dsfr/Badge";
 import Footer from "@codegouvfr/react-dsfr/Footer";
 import { Header } from "@codegouvfr/react-dsfr/Header";
 import Tooltip from "@codegouvfr/react-dsfr/Tooltip";
-import { createRootRouteWithContext, type LinkProps, Outlet, redirect, useLoaderData } from "@tanstack/react-router";
+import {
+  createRootRouteWithContext,
+  type LinkProps,
+  Outlet,
+  redirect,
+  useLoaderData,
+} from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import * as React from "react";
 import { useMemo } from "react";
@@ -78,7 +87,7 @@ const EspaceRedacteur = () => {
           </>
         ),
         linkProps: {
-          to: "/dossiers",
+          to: "/dossiers/rechercher",
         },
       });
     }

--- a/frontend/src/apps/agent/fip6/routes/dossiers/en-instruction.tsx
+++ b/frontend/src/apps/agent/fip6/routes/dossiers/en-instruction.tsx
@@ -1,0 +1,127 @@
+import { AgentContext } from "@/apps/agent/_commun/contexts/AgentContext.ts";
+import { DossierEnInstruction } from "@/apps/agent/fip6/modeles";
+import { dateSimple, periode } from "@/common/services/date.ts";
+import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
+import { createFileRoute } from "@tanstack/react-router";
+import { plainToInstance } from "class-transformer";
+import React, { useEffect, useState } from "react";
+
+export const Route = createFileRoute("/dossiers/en-instruction")({
+  beforeLoad: async ({ context }: { context: AgentContext }) => {
+    // TDOO: s'assurer que l'agent est rédacteur
+  },
+  component: ListeDossierEnInstruction,
+});
+
+function ListeDossierEnInstruction() {
+  const [dossiers, setDossiers]: [
+    DossierEnInstruction[],
+    (dossiers: DossierEnInstruction[]) => void,
+  ] = useState<DossierEnInstruction[]>([]);
+
+  // TODO utiliser une tanstack query ici (notamment en vue de la mutation)
+  useEffect(() => {
+    fetch("/api/agent/fip6/dossiers/liste/en-instruction")
+      .then((response) => response.json())
+      .then((data) =>
+        setDossiers(plainToInstance(DossierEnInstruction, data as any[])),
+      );
+  }, []);
+
+  return (
+    <>
+      <h1>Dossiers en cours d'instruction</h1>
+
+      <p>Vous avez démarrer l'instruction des dossiers ci-dessous.</p>
+
+      <h4>
+        {dossiers.length ? (
+          <>
+            {dossiers.length} dossier{dossiers.length > 1 ? "s" : ""}
+          </>
+        ) : (
+          <>Aucun dossier</>
+        )}
+      </h4>
+
+      <div>
+        {dossiers.map((dossier: DossierEnInstruction) => (
+          <DossierEnInstructionLigne
+            key={`dossier-a-attribuer-${dossier.id}`}
+            dossier={dossier}
+          />
+        ))}
+      </div>
+    </>
+  );
+}
+
+function DossierEnInstructionLigne({
+  dossier,
+}: {
+  dossier: DossierEnInstruction;
+}) {
+  return (
+    <div className="fr-grid-row mij-dossier-liste-element">
+      <div className="fr-col-3">
+        <strong className="fr-text--bold fr-text--lg">
+          {dossier.reference}
+        </strong>
+      </div>
+
+      <div className="fr-col-7 mij-dossier-details">
+        <ul>
+          <li>{dossier.requerant}</li>
+          <li>
+            {dossier.adresse ? (
+              dossier.adresse
+            ) : (
+              <>
+                adresse <i>non renseignée</i>
+              </>
+            )}
+          </li>
+          <li>
+            intervention{" "}
+            {dossier.dateOperation ? (
+              <>le {dateSimple(dossier.dateOperation)}</>
+            ) : (
+              <>
+                à une date <i>non renseignée</i>
+              </>
+            )}
+          </li>
+          <li>publié il y a {periode(dossier.datePublication)}</li>
+          <li>
+            instruction démarrée il y a {periode(dossier.dateDebutInstruction)}
+          </li>
+        </ul>
+      </div>
+
+      <div className="fr-col-2">
+        <ButtonsGroup
+          inlineLayoutWhen="always"
+          alignment="right"
+          buttonsIconPosition="left"
+          buttonsEquisized={false}
+          buttonsSize="small"
+          buttons={[
+            {
+              size: "small",
+              priority: "tertiary no outline",
+              iconId: "fr-icon-eye-line",
+              children: "Consulter",
+              className: "fr-mb-0",
+              linkProps: {
+                to: "/dossier/$id",
+                params: {
+                  id: dossier.id,
+                },
+              },
+            },
+          ]}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/apps/agent/fip6/routes/dossiers/index.tsx
+++ b/frontend/src/apps/agent/fip6/routes/dossiers/index.tsx
@@ -1,18 +1,8 @@
-import { AgentContext } from "@/apps/agent/_commun/contexts";
-import { validerParametres } from "@/apps/agent/fip6/composants/routes/RechercherRoute.tsx";
-import { container } from "@/apps/agent/fip6/container";
-import { AgentManagerInterface } from "@/common/services/agent/agent.ts";
 import "@/style/agents.css";
 import { createFileRoute, Navigate } from "@tanstack/react-router";
 import React from "react";
 
 export const Route = createFileRoute("/dossiers/")({
-  loader: async ({ context }: { context: AgentContext }) => ({
-    agent: context.agent,
-    // TODO transformer par un appel API
-    redacteurs: await container.get(AgentManagerInterface.$).redacteurs(),
-  }),
-  validateSearch: validerParametres,
   component: IndexDossiers,
 });
 

--- a/frontend/src/apps/agent/fip6/routes/dossiers/mes-dossiers.tsx
+++ b/frontend/src/apps/agent/fip6/routes/dossiers/mes-dossiers.tsx
@@ -1,12 +1,17 @@
 import { AgentContext } from "@/apps/agent/_commun/contexts";
 import {
-  RechercherRoute,
-  validerParametres,
-} from "@/apps/agent/fip6/composants/routes/RechercherRoute.tsx";
+  RechercherDossierPage,
+  RechercheRequete,
+  requeteVersParametres,
+  validerParametres
+} from "@/apps/agent/fip6/composants/pages/RechercherDossierPage.tsx";
 import { container } from "@/apps/agent/fip6/container";
+import { Agent, EtatDossierType, Redacteur } from "@/common/models";
 import { AgentManagerInterface } from "@/common/services/agent/agent.ts";
 import "@/style/agents.css";
+import { RegisteredLinkProps } from "@codegouvfr/react-dsfr/src/link.tsx";
 import { createFileRoute } from "@tanstack/react-router";
+import React, { useMemo } from "react";
 
 export const Route = createFileRoute("/dossiers/mes-dossiers")({
   loader: async ({ context }: { context: AgentContext }) => ({
@@ -17,10 +22,82 @@ export const Route = createFileRoute("/dossiers/mes-dossiers")({
   validateSearch: async (
     search: Record<string, string | string[] | undefined>,
   ) => {
+    // On exclue le paramètre 'a', pour la liste des attributaires, de la recherche
+    const { p, e, r } = validerParametres(search);
+
     return {
-      ...validerParametres(search),
-      a: "17",
+      p,
+      e,
+      r,
     };
   },
-  component: RechercherRoute,
+  component: MesDossiersComposant,
 });
+
+function MesDossiersComposant() {
+  // Récupérer l'agent actuellement connecté
+  const { agent, redacteurs }: { agent: Agent; redacteurs: Redacteur[] } =
+    Route.useLoaderData();
+
+  // Récupérer les paramètres de recherche
+  const {
+    p,
+    a,
+    e,
+    r,
+  }: {
+    p: number;
+    a?: string;
+    e?: string;
+    r?: string;
+  } = Route.useSearch();
+
+  // L'état de la requête de recherche de dossiers, calculée à partir des paramères GET
+  const requete: RechercheRequete = useMemo<RechercheRequete>(() => {
+    const etats = e?.split("|");
+    const attributaires = a?.split("|").map((id) => parseInt(id));
+
+    return {
+      etatsDossier: etats
+        ? EtatDossierType.liste.filter((e) => etats.includes(e.slug))
+        : [
+            EtatDossierType.A_ATTRIBUER,
+            EtatDossierType.A_INSTRUIRE,
+            EtatDossierType.EN_INSTRUCTION,
+            EtatDossierType.OK_A_SIGNER,
+            EtatDossierType.OK_A_APPROUVER,
+            EtatDossierType.OK_A_VERIFIER,
+            EtatDossierType.OK_VERIFIE,
+            EtatDossierType.OK_A_INDEMNISER,
+            EtatDossierType.OK_EN_ATTENTE_PAIEMENT,
+            EtatDossierType.OK_INDEMNISE,
+            EtatDossierType.KO_A_SIGNER,
+            EtatDossierType.KO_REJETE,
+          ],
+      attributaires: [agent],
+      inclureDossierNonAttribue: !!a?.split("|").find((v) => v === "_"),
+      recherche: r ?? "",
+      page: p,
+    };
+  }, [p, e, a, r]);
+
+  return (
+    <RechercherDossierPage
+      agent={agent}
+      redacteurs={redacteurs}
+      requete={requete}
+      construireLien={({ changement }): RegisteredLinkProps => {
+        const { p, e, r } = requeteVersParametres({
+          ...requete,
+          ...changement,
+        });
+
+        return {
+          to: Route.fullPath,
+          search: { p, e, r },
+        } as RegisteredLinkProps;
+      }}
+      activerFiltreAttributaires={false}
+    />
+  );
+}

--- a/frontend/src/apps/agent/fip6/routes/dossiers/mes-dossiers.tsx
+++ b/frontend/src/apps/agent/fip6/routes/dossiers/mes-dossiers.tsx
@@ -1,21 +1,26 @@
 import { AgentContext } from "@/apps/agent/_commun/contexts";
-import { validerParametres } from "@/apps/agent/fip6/composants/routes/RechercherRoute.tsx";
+import {
+  RechercherRoute,
+  validerParametres,
+} from "@/apps/agent/fip6/composants/routes/RechercherRoute.tsx";
 import { container } from "@/apps/agent/fip6/container";
 import { AgentManagerInterface } from "@/common/services/agent/agent.ts";
 import "@/style/agents.css";
-import { createFileRoute, Navigate } from "@tanstack/react-router";
-import React from "react";
+import { createFileRoute } from "@tanstack/react-router";
 
-export const Route = createFileRoute("/dossiers/")({
+export const Route = createFileRoute("/dossiers/mes-dossiers")({
   loader: async ({ context }: { context: AgentContext }) => ({
     agent: context.agent,
     // TODO transformer par un appel API
     redacteurs: await container.get(AgentManagerInterface.$).redacteurs(),
   }),
-  validateSearch: validerParametres,
-  component: IndexDossiers,
+  validateSearch: async (
+    search: Record<string, string | string[] | undefined>,
+  ) => {
+    return {
+      ...validerParametres(search),
+      a: "17",
+    };
+  },
+  component: RechercherRoute,
 });
-
-function IndexDossiers() {
-  return <Navigate to="/dossiers/rechercher" search={{} as any} />;
-}

--- a/frontend/src/apps/agent/fip6/routes/dossiers/rechercher.tsx
+++ b/frontend/src/apps/agent/fip6/routes/dossiers/rechercher.tsx
@@ -1,9 +1,17 @@
 import { AgentContext } from "@/apps/agent/_commun/contexts";
-import { RechercherRoute, validerParametres } from "@/apps/agent/fip6/composants/routes/RechercherRoute.tsx";
+import {
+  RechercherDossierPage,
+  RechercheRequete,
+  requeteVersParametres,
+  validerParametres,
+} from "@/apps/agent/fip6/composants/pages/RechercherDossierPage.tsx";
 import { container } from "@/apps/agent/fip6/container";
+import { Agent, EtatDossierType, Redacteur } from "@/common/models";
 import { AgentManagerInterface } from "@/common/services/agent/agent.ts";
 import "@/style/agents.css";
+import { RegisteredLinkProps } from "@codegouvfr/react-dsfr/src/link.tsx";
 import { createFileRoute } from "@tanstack/react-router";
+import React, { useMemo } from "react";
 
 export const Route = createFileRoute("/dossiers/rechercher")({
   loader: async ({ context }: { context: AgentContext }) => ({
@@ -12,5 +20,71 @@ export const Route = createFileRoute("/dossiers/rechercher")({
     redacteurs: await container.get(AgentManagerInterface.$).redacteurs(),
   }),
   validateSearch: validerParametres,
-  component: RechercherRoute,
+  component: RechercherComposant,
 });
+
+function RechercherComposant() {
+  // Récupérer l'agent actuellement connecté
+  const { agent, redacteurs }: { agent: Agent; redacteurs: Redacteur[] } =
+    Route.useLoaderData();
+
+  // Récupérer les paramètres de recherche
+  const {
+    p,
+    a,
+    e,
+    r,
+  }: {
+    p: number;
+    a?: string;
+    e?: string;
+    r?: string;
+  } = Route.useSearch();
+
+  // L'état de la requête de recherche de dossiers, calculée à partir des paramères GET
+  const requete: RechercheRequete = useMemo<RechercheRequete>(() => {
+    const etats = e?.split("|");
+    const attributaires = a?.split("|").map((id) => parseInt(id));
+
+    return {
+      etatsDossier: etats
+        ? EtatDossierType.liste.filter((e) => etats.includes(e.slug))
+        : [
+            EtatDossierType.A_ATTRIBUER,
+            EtatDossierType.A_INSTRUIRE,
+            EtatDossierType.EN_INSTRUCTION,
+            EtatDossierType.OK_A_SIGNER,
+            EtatDossierType.OK_A_APPROUVER,
+            EtatDossierType.OK_A_VERIFIER,
+            EtatDossierType.OK_VERIFIE,
+            EtatDossierType.OK_A_INDEMNISER,
+            EtatDossierType.OK_EN_ATTENTE_PAIEMENT,
+            EtatDossierType.OK_INDEMNISE,
+            EtatDossierType.KO_A_SIGNER,
+            EtatDossierType.KO_REJETE,
+          ],
+      attributaires: attributaires
+        ? redacteurs.filter((redacteur: Redacteur) =>
+            attributaires.includes(redacteur.id),
+          )
+        : [],
+      inclureDossierNonAttribue: !!a?.split("|").find((v) => v === "_"),
+      recherche: r ?? "",
+      page: p,
+    };
+  }, [p, e, a, r]);
+
+  return (
+    <RechercherDossierPage
+      agent={agent}
+      redacteurs={redacteurs}
+      requete={requete}
+      construireLien={({ changement }): RegisteredLinkProps => {
+        return {
+          to: Route.fullPath,
+          search: requeteVersParametres({ ...requete, ...changement }),
+        } as RegisteredLinkProps;
+      }}
+    />
+  );
+}

--- a/frontend/src/apps/agent/fip6/routes/dossiers/rechercher.tsx
+++ b/frontend/src/apps/agent/fip6/routes/dossiers/rechercher.tsx
@@ -1,21 +1,16 @@
 import { AgentContext } from "@/apps/agent/_commun/contexts";
-import { validerParametres } from "@/apps/agent/fip6/composants/routes/RechercherRoute.tsx";
+import { RechercherRoute, validerParametres } from "@/apps/agent/fip6/composants/routes/RechercherRoute.tsx";
 import { container } from "@/apps/agent/fip6/container";
 import { AgentManagerInterface } from "@/common/services/agent/agent.ts";
 import "@/style/agents.css";
-import { createFileRoute, Navigate } from "@tanstack/react-router";
-import React from "react";
+import { createFileRoute } from "@tanstack/react-router";
 
-export const Route = createFileRoute("/dossiers/")({
+export const Route = createFileRoute("/dossiers/rechercher")({
   loader: async ({ context }: { context: AgentContext }) => ({
     agent: context.agent,
     // TODO transformer par un appel API
     redacteurs: await container.get(AgentManagerInterface.$).redacteurs(),
   }),
   validateSearch: validerParametres,
-  component: IndexDossiers,
+  component: RechercherRoute,
 });
-
-function IndexDossiers() {
-  return <Navigate to="/dossiers/rechercher" search={{} as any} />;
-}

--- a/frontend/src/apps/agent/fip6/routeur/routeur-fip6.gen.ts
+++ b/frontend/src/apps/agent/fip6/routeur/routeur-fip6.gen.ts
@@ -14,7 +14,9 @@ import { Route as IndexRouteImport } from './../routes/index'
 import { Route as DossiersIndexRouteImport } from './../routes/dossiers/index'
 import { Route as DossierIndexRouteImport } from './../routes/dossier/index'
 import { Route as DossiersRejetASignerRouteImport } from './../routes/dossiers/rejet-a-signer'
+import { Route as DossiersRechercherRouteImport } from './../routes/dossiers/rechercher'
 import { Route as DossiersPropositionASignerRouteImport } from './../routes/dossiers/proposition-a-signer'
+import { Route as DossiersMesDossiersRouteImport } from './../routes/dossiers/mes-dossiers'
 import { Route as DossiersEnInstructionRouteImport } from './../routes/dossiers/en-instruction'
 import { Route as DossiersEnAttenteIndemnisationRouteImport } from './../routes/dossiers/en-attente-indemnisation'
 import { Route as DossiersArreteASignerRouteImport } from './../routes/dossiers/arrete-a-signer'
@@ -51,12 +53,22 @@ const DossiersRejetASignerRoute = DossiersRejetASignerRouteImport.update({
   path: '/dossiers/rejet-a-signer',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DossiersRechercherRoute = DossiersRechercherRouteImport.update({
+  id: '/dossiers/rechercher',
+  path: '/dossiers/rechercher',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DossiersPropositionASignerRoute =
   DossiersPropositionASignerRouteImport.update({
     id: '/dossiers/proposition-a-signer',
     path: '/dossiers/proposition-a-signer',
     getParentRoute: () => rootRouteImport,
   } as any)
+const DossiersMesDossiersRoute = DossiersMesDossiersRouteImport.update({
+  id: '/dossiers/mes-dossiers',
+  path: '/dossiers/mes-dossiers',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DossiersEnInstructionRoute = DossiersEnInstructionRouteImport.update({
   id: '/dossiers/en-instruction',
   path: '/dossiers/en-instruction',
@@ -121,7 +133,9 @@ export interface FileRoutesByFullPath {
   '/dossiers/arrete-a-signer': typeof DossiersArreteASignerRoute
   '/dossiers/en-attente-indemnisation': typeof DossiersEnAttenteIndemnisationRoute
   '/dossiers/en-instruction': typeof DossiersEnInstructionRoute
+  '/dossiers/mes-dossiers': typeof DossiersMesDossiersRoute
   '/dossiers/proposition-a-signer': typeof DossiersPropositionASignerRoute
+  '/dossiers/rechercher': typeof DossiersRechercherRoute
   '/dossiers/rejet-a-signer': typeof DossiersRejetASignerRoute
   '/dossier': typeof DossierIndexRoute
   '/dossiers': typeof DossiersIndexRoute
@@ -139,7 +153,9 @@ export interface FileRoutesByTo {
   '/dossiers/arrete-a-signer': typeof DossiersArreteASignerRoute
   '/dossiers/en-attente-indemnisation': typeof DossiersEnAttenteIndemnisationRoute
   '/dossiers/en-instruction': typeof DossiersEnInstructionRoute
+  '/dossiers/mes-dossiers': typeof DossiersMesDossiersRoute
   '/dossiers/proposition-a-signer': typeof DossiersPropositionASignerRoute
+  '/dossiers/rechercher': typeof DossiersRechercherRoute
   '/dossiers/rejet-a-signer': typeof DossiersRejetASignerRoute
   '/dossier': typeof DossierIndexRoute
   '/dossiers': typeof DossiersIndexRoute
@@ -158,7 +174,9 @@ export interface FileRoutesById {
   '/dossiers/arrete-a-signer': typeof DossiersArreteASignerRoute
   '/dossiers/en-attente-indemnisation': typeof DossiersEnAttenteIndemnisationRoute
   '/dossiers/en-instruction': typeof DossiersEnInstructionRoute
+  '/dossiers/mes-dossiers': typeof DossiersMesDossiersRoute
   '/dossiers/proposition-a-signer': typeof DossiersPropositionASignerRoute
+  '/dossiers/rechercher': typeof DossiersRechercherRoute
   '/dossiers/rejet-a-signer': typeof DossiersRejetASignerRoute
   '/dossier/': typeof DossierIndexRoute
   '/dossiers/': typeof DossiersIndexRoute
@@ -178,7 +196,9 @@ export interface FileRouteTypes {
     | '/dossiers/arrete-a-signer'
     | '/dossiers/en-attente-indemnisation'
     | '/dossiers/en-instruction'
+    | '/dossiers/mes-dossiers'
     | '/dossiers/proposition-a-signer'
+    | '/dossiers/rechercher'
     | '/dossiers/rejet-a-signer'
     | '/dossier'
     | '/dossiers'
@@ -196,7 +216,9 @@ export interface FileRouteTypes {
     | '/dossiers/arrete-a-signer'
     | '/dossiers/en-attente-indemnisation'
     | '/dossiers/en-instruction'
+    | '/dossiers/mes-dossiers'
     | '/dossiers/proposition-a-signer'
+    | '/dossiers/rechercher'
     | '/dossiers/rejet-a-signer'
     | '/dossier'
     | '/dossiers'
@@ -214,7 +236,9 @@ export interface FileRouteTypes {
     | '/dossiers/arrete-a-signer'
     | '/dossiers/en-attente-indemnisation'
     | '/dossiers/en-instruction'
+    | '/dossiers/mes-dossiers'
     | '/dossiers/proposition-a-signer'
+    | '/dossiers/rechercher'
     | '/dossiers/rejet-a-signer'
     | '/dossier/'
     | '/dossiers/'
@@ -233,7 +257,9 @@ export interface RootRouteChildren {
   DossiersArreteASignerRoute: typeof DossiersArreteASignerRoute
   DossiersEnAttenteIndemnisationRoute: typeof DossiersEnAttenteIndemnisationRoute
   DossiersEnInstructionRoute: typeof DossiersEnInstructionRoute
+  DossiersMesDossiersRoute: typeof DossiersMesDossiersRoute
   DossiersPropositionASignerRoute: typeof DossiersPropositionASignerRoute
+  DossiersRechercherRoute: typeof DossiersRechercherRoute
   DossiersRejetASignerRoute: typeof DossiersRejetASignerRoute
   DossierIndexRoute: typeof DossierIndexRoute
   DossiersIndexRoute: typeof DossiersIndexRoute
@@ -277,11 +303,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DossiersRejetASignerRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/dossiers/rechercher': {
+      id: '/dossiers/rechercher'
+      path: '/dossiers/rechercher'
+      fullPath: '/dossiers/rechercher'
+      preLoaderRoute: typeof DossiersRechercherRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/dossiers/proposition-a-signer': {
       id: '/dossiers/proposition-a-signer'
       path: '/dossiers/proposition-a-signer'
       fullPath: '/dossiers/proposition-a-signer'
       preLoaderRoute: typeof DossiersPropositionASignerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dossiers/mes-dossiers': {
+      id: '/dossiers/mes-dossiers'
+      path: '/dossiers/mes-dossiers'
+      fullPath: '/dossiers/mes-dossiers'
+      preLoaderRoute: typeof DossiersMesDossiersRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/dossiers/en-instruction': {
@@ -369,7 +409,9 @@ const rootRouteChildren: RootRouteChildren = {
   DossiersArreteASignerRoute: DossiersArreteASignerRoute,
   DossiersEnAttenteIndemnisationRoute: DossiersEnAttenteIndemnisationRoute,
   DossiersEnInstructionRoute: DossiersEnInstructionRoute,
+  DossiersMesDossiersRoute: DossiersMesDossiersRoute,
   DossiersPropositionASignerRoute: DossiersPropositionASignerRoute,
+  DossiersRechercherRoute: DossiersRechercherRoute,
   DossiersRejetASignerRoute: DossiersRejetASignerRoute,
   DossierIndexRoute: DossierIndexRoute,
   DossiersIndexRoute: DossiersIndexRoute,

--- a/frontend/src/apps/agent/fip6/routeur/routeur-fip6.gen.ts
+++ b/frontend/src/apps/agent/fip6/routeur/routeur-fip6.gen.ts
@@ -15,6 +15,7 @@ import { Route as DossiersIndexRouteImport } from './../routes/dossiers/index'
 import { Route as DossierIndexRouteImport } from './../routes/dossier/index'
 import { Route as DossiersRejetASignerRouteImport } from './../routes/dossiers/rejet-a-signer'
 import { Route as DossiersPropositionASignerRouteImport } from './../routes/dossiers/proposition-a-signer'
+import { Route as DossiersEnInstructionRouteImport } from './../routes/dossiers/en-instruction'
 import { Route as DossiersEnAttenteIndemnisationRouteImport } from './../routes/dossiers/en-attente-indemnisation'
 import { Route as DossiersArreteASignerRouteImport } from './../routes/dossiers/arrete-a-signer'
 import { Route as DossiersAVerifierRouteImport } from './../routes/dossiers/a-verifier'
@@ -56,6 +57,11 @@ const DossiersPropositionASignerRoute =
     path: '/dossiers/proposition-a-signer',
     getParentRoute: () => rootRouteImport,
   } as any)
+const DossiersEnInstructionRoute = DossiersEnInstructionRouteImport.update({
+  id: '/dossiers/en-instruction',
+  path: '/dossiers/en-instruction',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DossiersEnAttenteIndemnisationRoute =
   DossiersEnAttenteIndemnisationRouteImport.update({
     id: '/dossiers/en-attente-indemnisation',
@@ -114,6 +120,7 @@ export interface FileRoutesByFullPath {
   '/dossiers/a-verifier': typeof DossiersAVerifierRoute
   '/dossiers/arrete-a-signer': typeof DossiersArreteASignerRoute
   '/dossiers/en-attente-indemnisation': typeof DossiersEnAttenteIndemnisationRoute
+  '/dossiers/en-instruction': typeof DossiersEnInstructionRoute
   '/dossiers/proposition-a-signer': typeof DossiersPropositionASignerRoute
   '/dossiers/rejet-a-signer': typeof DossiersRejetASignerRoute
   '/dossier': typeof DossierIndexRoute
@@ -131,6 +138,7 @@ export interface FileRoutesByTo {
   '/dossiers/a-verifier': typeof DossiersAVerifierRoute
   '/dossiers/arrete-a-signer': typeof DossiersArreteASignerRoute
   '/dossiers/en-attente-indemnisation': typeof DossiersEnAttenteIndemnisationRoute
+  '/dossiers/en-instruction': typeof DossiersEnInstructionRoute
   '/dossiers/proposition-a-signer': typeof DossiersPropositionASignerRoute
   '/dossiers/rejet-a-signer': typeof DossiersRejetASignerRoute
   '/dossier': typeof DossierIndexRoute
@@ -149,6 +157,7 @@ export interface FileRoutesById {
   '/dossiers/a-verifier': typeof DossiersAVerifierRoute
   '/dossiers/arrete-a-signer': typeof DossiersArreteASignerRoute
   '/dossiers/en-attente-indemnisation': typeof DossiersEnAttenteIndemnisationRoute
+  '/dossiers/en-instruction': typeof DossiersEnInstructionRoute
   '/dossiers/proposition-a-signer': typeof DossiersPropositionASignerRoute
   '/dossiers/rejet-a-signer': typeof DossiersRejetASignerRoute
   '/dossier/': typeof DossierIndexRoute
@@ -168,6 +177,7 @@ export interface FileRouteTypes {
     | '/dossiers/a-verifier'
     | '/dossiers/arrete-a-signer'
     | '/dossiers/en-attente-indemnisation'
+    | '/dossiers/en-instruction'
     | '/dossiers/proposition-a-signer'
     | '/dossiers/rejet-a-signer'
     | '/dossier'
@@ -185,6 +195,7 @@ export interface FileRouteTypes {
     | '/dossiers/a-verifier'
     | '/dossiers/arrete-a-signer'
     | '/dossiers/en-attente-indemnisation'
+    | '/dossiers/en-instruction'
     | '/dossiers/proposition-a-signer'
     | '/dossiers/rejet-a-signer'
     | '/dossier'
@@ -202,6 +213,7 @@ export interface FileRouteTypes {
     | '/dossiers/a-verifier'
     | '/dossiers/arrete-a-signer'
     | '/dossiers/en-attente-indemnisation'
+    | '/dossiers/en-instruction'
     | '/dossiers/proposition-a-signer'
     | '/dossiers/rejet-a-signer'
     | '/dossier/'
@@ -220,6 +232,7 @@ export interface RootRouteChildren {
   DossiersAVerifierRoute: typeof DossiersAVerifierRoute
   DossiersArreteASignerRoute: typeof DossiersArreteASignerRoute
   DossiersEnAttenteIndemnisationRoute: typeof DossiersEnAttenteIndemnisationRoute
+  DossiersEnInstructionRoute: typeof DossiersEnInstructionRoute
   DossiersPropositionASignerRoute: typeof DossiersPropositionASignerRoute
   DossiersRejetASignerRoute: typeof DossiersRejetASignerRoute
   DossierIndexRoute: typeof DossierIndexRoute
@@ -269,6 +282,13 @@ declare module '@tanstack/react-router' {
       path: '/dossiers/proposition-a-signer'
       fullPath: '/dossiers/proposition-a-signer'
       preLoaderRoute: typeof DossiersPropositionASignerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dossiers/en-instruction': {
+      id: '/dossiers/en-instruction'
+      path: '/dossiers/en-instruction'
+      fullPath: '/dossiers/en-instruction'
+      preLoaderRoute: typeof DossiersEnInstructionRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/dossiers/en-attente-indemnisation': {
@@ -348,6 +368,7 @@ const rootRouteChildren: RootRouteChildren = {
   DossiersAVerifierRoute: DossiersAVerifierRoute,
   DossiersArreteASignerRoute: DossiersArreteASignerRoute,
   DossiersEnAttenteIndemnisationRoute: DossiersEnAttenteIndemnisationRoute,
+  DossiersEnInstructionRoute: DossiersEnInstructionRoute,
   DossiersPropositionASignerRoute: DossiersPropositionASignerRoute,
   DossiersRejetASignerRoute: DossiersRejetASignerRoute,
   DossierIndexRoute: DossierIndexRoute,

--- a/frontend/src/apps/agent/fip6/services/dossier.ts
+++ b/frontend/src/apps/agent/fip6/services/dossier.ts
@@ -1,10 +1,5 @@
 import { queryClient } from "@/apps/agent/fip6/query.ts";
-import {
-  BaseDossier,
-  Document,
-  DocumentType,
-  DossierDetail,
-} from "@/common/models";
+import { BaseDossier, Document, DocumentType, DossierDetail } from "@/common/models";
 import { plainToInstance } from "class-transformer";
 import { ServiceIdentifier } from "inversify";
 
@@ -12,6 +7,7 @@ export type ListeDossier =
   | "a-categoriser"
   | "a-attribuer"
   | "a-instruire"
+  | "en-instruction"
   | "rejet-a-signer"
   | "proposition-a-signer"
   | "a-verifier"

--- a/frontend/src/common/services/date.ts
+++ b/frontend/src/common/services/date.ts
@@ -20,7 +20,9 @@ export const memeJour = (a: Date, b: Date): boolean => {
   );
 };
 
-export const periode = (de: Date, a: Date = new Date()): string => {
+export const periode = (de: Date, a: Date | undefined = undefined): string => {
+  a = a ?? new Date();
+
   // Différence en secondes
   let diff = (a.getTime() - de.getTime()) / 1000;
 

--- a/frontend/tests/tsconfig.json
+++ b/frontend/tests/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["src/**"],
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -32,6 +32,5 @@
     "src/style/**/*",
     "src/apps/_init.ts",
     "src/apps/sentry.ts",
-    "src/apps/agent/_commun/**/*"
   ]
 }


### PR DESCRIPTION
# Scinder la liste des dossiers du rédacteur

Un rédacteur a des dossiers à instruire et d'autres déjà en cours d'instruction (il suffit juste de cliquer sur un bouton "Démarrer l'instruction", c'est juste déclaratif).

Jusqu'à aujourd'hui, le listing des dossiers à instruire regroupait les 2, ici l'objectif est de les scinder en 2 vues distinctes. 

@Wafa-ba je te mets en revieweuse pour te permettre d'avoir un aperçu de comment l'espace rédacteur (FIP6) est conçu, mais sens-toi libre de me faire des retours