### PR TITLE
Ne faire apparaitre la déclaration que si elle est acceptée par le requérant

### DIFF
--- a/frontend/src/apps/agent/fip6/routes/dossier/$id/index.tsx
+++ b/frontend/src/apps/agent/fip6/routes/dossier/$id/index.tsx
@@ -5,7 +5,7 @@ import { QuillEditor } from "@/apps/agent/fip6/dossiers/components/consultation/
 import { InfosDossier } from "@/apps/agent/fip6/dossiers/components/consultation/InfosDossier";
 import {
   ChampPieceJointe,
-  TelechargerPieceJointe
+  TelechargerPieceJointe,
 } from "@/apps/agent/fip6/dossiers/components/consultation/piecejointe";
 import { PiecesJointes } from "@/apps/agent/fip6/dossiers/components/consultation/PiecesJointes";
 import { DossierManagerInterface } from "@/apps/agent/fip6/services/dossier";
@@ -336,28 +336,24 @@ const ConsultationDossier = observer(function ConsultationDossier({
                   </section>
                 )}
 
-                {selectedTab == "declaration" && (
-                  <section>
-                    <h3>Déclaration d'acceptation</h3>
-                    {dossier.getDeclarationAcceptation() && (
-                      <>
-                        <TelechargerPieceJointe
-                          className="fr-grid-row fr-col-12"
-                          pieceJointe={
-                            dossier.getDeclarationAcceptation() as Document
-                          }
-                        />
-
-                        <ChampPieceJointe
-                          className="fr-col-12"
-                          pieceJointe={
-                            dossier.getDeclarationAcceptation() as Document
-                          }
-                        />
-                      </>
-                    )}
-                  </section>
-                )}
+                {selectedTab == "declaration" &&
+                  dossier.estAccepteRequerant() && (
+                    <section>
+                      <h3>Déclaration d'acceptation</h3>
+                      <TelechargerPieceJointe
+                        className="fr-grid-row fr-col-12"
+                        pieceJointe={
+                          dossier.getDeclarationAcceptation() as Document
+                        }
+                      />
+                      <ChampPieceJointe
+                        className="fr-col-12"
+                        pieceJointe={
+                          dossier.getDeclarationAcceptation() as Document
+                        }
+                      />
+                    </section>
+                  )}
 
                 {selectedTab == "arrete" && (
                   <section>

--- a/frontend/src/common/models/EtatDossier.ts
+++ b/frontend/src/common/models/EtatDossier.ts
@@ -129,10 +129,12 @@ export class EtatDossierType implements EtatInterface {
 
   public estAccepteRequerant(): boolean {
     return [
-      EtatDossierType.OK_A_VERIFIER.id,
-      EtatDossierType.OK_A_INDEMNISER.id,
-      EtatDossierType.OK_INDEMNISE.id,
-    ].includes(this.id);
+      EtatDossierType.OK_A_VERIFIER,
+      EtatDossierType.OK_VERIFIE,
+      EtatDossierType.OK_A_INDEMNISER,
+      EtatDossierType.OK_EN_ATTENTE_PAIEMENT,
+      EtatDossierType.OK_INDEMNISE,
+    ].includes(this);
   }
 
   public estIndemnise(): boolean {


### PR DESCRIPTION
# Ne faire apparaitre la déclaration que si elle est acceptée par le requérant

Sur la vue dossier, l'onglet "Déclaration d'acceptation" n'apparait que si la déclaration d'acceptation a été retournée par le requérant