### PR TITLE
Renommer le TestEligibilite actuel pour préciser qu'il concerne les bris de porte

### DIFF
--- a/backend/migrations/Version20260610131925.php
+++ b/backend/migrations/Version20260610131925.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260610131925 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Renommer la table eligibilite_tests en bris_porte_test_eligibilite pour préparer la distinction avec celui des dysfonctionnements';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE eligibilite_tests RENAME TO bris_porte_test_eligibilite');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE bris_porte_test_eligibilite RENAME TO eligibilite_tests');
+    }
+}

--- a/backend/src/Api/Agent/Fip6/Output/DossierDetailOutput.php
+++ b/backend/src/Api/Agent/Fip6/Output/DossierDetailOutput.php
@@ -25,7 +25,7 @@ readonly class DossierDetailOutput extends BaseDossierOutput
         public RequerantOutput $requerant,
         public AdresseOutput $adresse,
         // TODO implémenter
-        public ?TestEligibiliteOutput $testEligibilite,
+        public ?TestEligibiliteBrisPorteOutput $testEligibilite,
         public ?DeclarationFDOOutput $declarationFDO,
         public ?string $descriptionRequerant,
         public ?string $notes,
@@ -63,7 +63,7 @@ readonly class DossierDetailOutput extends BaseDossierOutput
             usager: UsagerOutput::depuisUsager($dossier->getUsager()),
             requerant: RequerantOutput::depuisRequerant($dossier->estPersonneMorale() ? $dossier->getRequerantPersonneMorale() : $dossier->getRequerantPersonnePhysique()),
             adresse: AdresseOutput::depuisAdresse($dossier->getBrisPorte()->getAdresse()),
-            testEligibilite: TestEligibiliteOutput::depuisTestEligibilite($dossier->getBrisPorte()->getTestEligibilite()),
+            testEligibilite: TestEligibiliteBrisPorteOutput::depuisTestEligibilite($dossier->getBrisPorte()->getTestEligibilite()),
             declarationFDO: DeclarationFDOOutput::depuisDeclarationFDOBrisPorte($dossier->getBrisPorte()->getDeclarationFDO()),
             descriptionRequerant: $dossier->getBrisPorte()->getDescriptionRequerant(),
             notes: $dossier->getNotes(),

--- a/backend/src/Api/Agent/Fip6/Output/TestEligibiliteBrisPorteOutput.php
+++ b/backend/src/Api/Agent/Fip6/Output/TestEligibiliteBrisPorteOutput.php
@@ -3,9 +3,9 @@
 namespace MonIndemnisationJustice\Api\Agent\Fip6\Output;
 
 use MonIndemnisationJustice\Entity\RapportAuLogement;
-use MonIndemnisationJustice\Entity\TestEligibilite;
+use MonIndemnisationJustice\Entity\TestEligibiliteBrisPorte;
 
-class TestEligibiliteOutput
+class TestEligibiliteBrisPorteOutput
 {
     public function __construct(
         public ?RapportAuLogement $rapportAuLogement,
@@ -16,7 +16,7 @@ class TestEligibiliteOutput
     ) {
     }
 
-    public static function depuisTestEligibilite(?TestEligibilite $testEligibilite = null): ?self
+    public static function depuisTestEligibilite(?TestEligibiliteBrisPorte $testEligibilite = null): ?self
     {
         if (null === $testEligibilite) {
             return null;

--- a/backend/src/Controller/BrisPorteController.php
+++ b/backend/src/Controller/BrisPorteController.php
@@ -10,9 +10,9 @@ use MonIndemnisationJustice\Entity\DeclarationFDOBrisPorte;
 use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\Metadonnees\NavigationRequerant;
 use MonIndemnisationJustice\Entity\Personne;
-use MonIndemnisationJustice\Entity\TestEligibilite;
+use MonIndemnisationJustice\Entity\TestEligibiliteBrisPorte;
 use MonIndemnisationJustice\Entity\Usager;
-use MonIndemnisationJustice\Forms\TestEligibiliteType;
+use MonIndemnisationJustice\Forms\TestEligibiliteBrisPorteType;
 use MonIndemnisationJustice\Security\Oidc\OidcClient;
 use MonIndemnisationJustice\Service\Mailer;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -31,7 +31,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 class PreInscription
 {
     public function __construct(
-        public ?TestEligibilite $testEligibilite = null,
+        public ?TestEligibiliteBrisPorte $testEligibilite = null,
         public ?DeclarationFDOBrisPorte $declarationErreurOperationnelle = null,
         public ?Usager $requerant = null,
     ) {
@@ -67,7 +67,7 @@ class BrisPorteController extends AbstractController
         }
 
         $preinscription = $this->getPreinscription($request);
-        $testEligibilite = $preinscription->testEligibilite ?? new TestEligibilite();
+        $testEligibilite = $preinscription->testEligibilite ?? new TestEligibiliteBrisPorte();
 
         if ($request->getSession()->has(AtterrissageController::SESSION_KEY)) {
             $testEligibilite->estIssuAttestation = true;
@@ -75,12 +75,12 @@ class BrisPorteController extends AbstractController
             $request->getSession()->remove(AtterrissageController::SESSION_KEY);
         }
 
-        $form = $this->createForm(TestEligibiliteType::class, $testEligibilite);
+        $form = $this->createForm(TestEligibiliteBrisPorteType::class, $testEligibilite);
 
         if (Request::METHOD_POST === $request->getMethod()) {
             $form->handleRequest($request);
             if ($form->isSubmitted() && $form->isValid()) {
-                /** @var TestEligibilite $testEligibilite */
+                /** @var TestEligibiliteBrisPorte $testEligibilite */
                 $testEligibilite = $form->getData();
 
                 $testEligibilite->estEligibleExperimentation = true;
@@ -307,7 +307,7 @@ class BrisPorteController extends AbstractController
         $session = $request->getSession()->get(self::CLEF_SESSION_PREINSCRIPTION, []);
 
         return new PreInscription(
-            testEligibilite: $this->chargerEntite(TestEligibilite::class, @$session['testEligibilite'] ?? $request->getSession()->get(self::CLEF_SESSION_TEST_ELIGIBILITE)),
+            testEligibilite: $this->chargerEntite(TestEligibiliteBrisPorte::class, @$session['testEligibilite'] ?? $request->getSession()->get(self::CLEF_SESSION_TEST_ELIGIBILITE)),
             declarationErreurOperationnelle: $this->chargerEntite(DeclarationFDOBrisPorte::class, @$session['declarationErreurOperationnelle']),
             requerant: $this->chargerEntite(Usager::class, @$session['requerant']),
         );

--- a/backend/src/DataFixtures/DossierFixture.php
+++ b/backend/src/DataFixtures/DossierFixture.php
@@ -22,7 +22,7 @@ use MonIndemnisationJustice\Entity\GeoPays;
 use MonIndemnisationJustice\Entity\PersonneMorale;
 use MonIndemnisationJustice\Entity\PersonnePhysique;
 use MonIndemnisationJustice\Entity\RapportAuLogement;
-use MonIndemnisationJustice\Entity\TestEligibilite;
+use MonIndemnisationJustice\Entity\TestEligibiliteBrisPorte;
 use MonIndemnisationJustice\Entity\Usager;
 use MonIndemnisationJustice\Service\DocumentManager;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -107,7 +107,7 @@ class DossierFixture extends Fixture implements DependentFixtureInterface
                     ->setRapportAuLogement(RapportAuLogement::PROPRIETAIRE)
                     ->setDescriptionRequerant('Porte fracturée tôt ce matin')
                     ->setTestEligibilite(
-                        TestEligibilite::fromArray([
+                        TestEligibiliteBrisPorte::fromArray([
                             'departement' => $this->getReference('departement-bouches-du-rhone', GeoDepartement::class),
                             'estVise' => false,
                             'estHebergeant' => false,
@@ -160,7 +160,7 @@ class DossierFixture extends Fixture implements DependentFixtureInterface
                             ->setLocalite($this->faker->city())
                     )
                     ->setTestEligibilite(
-                        $this->getReference('test-eligibilite-melun', TestEligibilite::class)
+                        $this->getReference('test-eligibilite-melun', TestEligibiliteBrisPorte::class)
                     )
                     ->setRapportAuLogement(RapportAuLogement::BAILLEUR)
             )
@@ -248,7 +248,7 @@ class DossierFixture extends Fixture implements DependentFixtureInterface
                             ->setCodePostal('77000')
                     )
                     ->setTestEligibilite(
-                        $this->getReference('test-eligibilite-ray-keran', TestEligibilite::class)
+                        $this->getReference('test-eligibilite-ray-keran', TestEligibiliteBrisPorte::class)
                     )
                     ->setRapportAuLogement(RapportAuLogement::LOCATAIRE)
             )
@@ -429,7 +429,7 @@ class DossierFixture extends Fixture implements DependentFixtureInterface
                     ->setAdresse($adresse)
                     ->setRapportAuLogement($donneesTestEligibilite['rapportAuLogement'])
                     ->setTestEligibilite(
-                        TestEligibilite::fromArray(
+                        TestEligibiliteBrisPorte::fromArray(
                             array_merge(
                                 $donneesTestEligibilite,
                                 [

--- a/backend/src/DataFixtures/TestEligibiliteFixture.php
+++ b/backend/src/DataFixtures/TestEligibiliteFixture.php
@@ -7,7 +7,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use MonIndemnisationJustice\Entity\GeoDepartement;
 use MonIndemnisationJustice\Entity\RapportAuLogement;
-use MonIndemnisationJustice\Entity\TestEligibilite;
+use MonIndemnisationJustice\Entity\TestEligibiliteBrisPorte;
 use MonIndemnisationJustice\Entity\Usager;
 
 class TestEligibiliteFixture extends Fixture implements DependentFixtureInterface
@@ -22,7 +22,7 @@ class TestEligibiliteFixture extends Fixture implements DependentFixtureInterfac
     public function load(ObjectManager $manager): void
     {
         foreach ([
-            'ray-keran' => TestEligibilite::fromArray([
+            'ray-keran' => TestEligibiliteBrisPorte::fromArray([
                 'departement' => $this->getReference('departement-ille-et-vilaine', GeoDepartement::class),
                 // 'description' => 'Porte fracturée tôt ce matin',
                 'estVise' => false,
@@ -33,7 +33,7 @@ class TestEligibiliteFixture extends Fixture implements DependentFixtureInterfac
                 'usager' => $this->getReference('requerant-ray', Usager::class),
                 'dateSoumission' => new \DateTimeImmutable('-7 days'),
             ]),
-            'melun' => TestEligibilite::fromArray([
+            'melun' => TestEligibiliteBrisPorte::fromArray([
                 'estVise' => false,
                 'estHebergeant' => false,
                 'rapportAuLogement' => RapportAuLogement::BAILLEUR,

--- a/backend/src/Entity/BrisPorte.php
+++ b/backend/src/Entity/BrisPorte.php
@@ -22,9 +22,9 @@ class BrisPorte
     #[ORM\OneToOne(targetEntity: Dossier::class, mappedBy: 'brisPorte')]
     protected Dossier $dossier;
 
-    #[ORM\OneToOne(targetEntity: TestEligibilite::class, inversedBy: 'dossier', cascade: ['persist', 'remove'])]
+    #[ORM\OneToOne(targetEntity: TestEligibiliteBrisPorte::class, inversedBy: 'dossier', cascade: ['persist', 'remove'])]
     #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
-    protected ?TestEligibilite $testEligibilite = null;
+    protected ?TestEligibiliteBrisPorte $testEligibilite = null;
 
     #[ORM\OneToOne(targetEntity: DeclarationFDOBrisPorte::class, mappedBy: 'brisPorte', cascade: ['persist'])]
     protected ?DeclarationFDOBrisPorte $declarationFDO = null;
@@ -65,12 +65,12 @@ class BrisPorte
         return $this->id;
     }
 
-    public function getTestEligibilite(): ?TestEligibilite
+    public function getTestEligibilite(): ?TestEligibiliteBrisPorte
     {
         return $this->testEligibilite;
     }
 
-    public function setTestEligibilite(?TestEligibilite $testEligibilite): self
+    public function setTestEligibilite(?TestEligibiliteBrisPorte $testEligibilite): self
     {
         $this->testEligibilite = $testEligibilite;
 

--- a/backend/src/Entity/Dossier.php
+++ b/backend/src/Entity/Dossier.php
@@ -558,7 +558,7 @@ class Dossier
         return new self()->setType(DossierType::BRIS_PORTE);
     }
 
-    public static function brisDePorteDepuisTestEligibilite(TestEligibilite $testEligibilite): Dossier
+    public static function brisDePorteDepuisTestEligibilite(TestEligibiliteBrisPorte $testEligibilite): Dossier
     {
         return Dossier::brisDePorte()
             ->setUsager($testEligibilite->usager)

--- a/backend/src/Entity/TestEligibiliteBrisPorte.php
+++ b/backend/src/Entity/TestEligibiliteBrisPorte.php
@@ -6,9 +6,9 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
-#[ORM\Table(name: 'eligibilite_tests')]
+#[ORM\Table(name: 'bris_porte_test_eligibilite')]
 #[ORM\HasLifecycleCallbacks]
-class TestEligibilite
+class TestEligibiliteBrisPorte
 {
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
@@ -63,9 +63,9 @@ class TestEligibilite
         return !$this->estVise && !$this->estHebergeant;
     }
 
-    public static function fromArray(array $values): TestEligibilite
+    public static function fromArray(array $values): TestEligibiliteBrisPorte
     {
-        $testEligibilite = new TestEligibilite();
+        $testEligibilite = new TestEligibiliteBrisPorte();
 
         $testEligibilite->departement = $values['departement'] ?? null;
         $testEligibilite->estEligibleExperimentation = $testEligibilite->departement?->estDeploye() ?? false;

--- a/backend/src/Event/Listener/ConnexionUsagerListener.php
+++ b/backend/src/Event/Listener/ConnexionUsagerListener.php
@@ -9,7 +9,7 @@ use MonIndemnisationJustice\Entity\BrisPorte;
 use MonIndemnisationJustice\Entity\DeclarationFDOBrisPorte;
 use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\PersonnePhysique;
-use MonIndemnisationJustice\Entity\TestEligibilite;
+use MonIndemnisationJustice\Entity\TestEligibiliteBrisPorte;
 use MonIndemnisationJustice\Entity\Usager;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -96,12 +96,12 @@ class ConnexionUsagerListener implements EventSubscriberInterface
         ];
     }
 
-    protected function getTestEligibiliteEnCours(Request $request, Usager $requerant): ?TestEligibilite
+    protected function getTestEligibiliteEnCours(Request $request, Usager $requerant): ?TestEligibiliteBrisPorte
     {
         $preInscription = $request->getSession()->get(PublicBrisPorteController::CLEF_SESSION_PREINSCRIPTION, []);
         $idTestEligibilite = $requerant->getNavigation()?->idTestEligibilite ?? @$preInscription['testEligibilite'] ?? null;
 
-        return $idTestEligibilite ? $this->em->find(TestEligibilite::class, $idTestEligibilite) : null;
+        return $idTestEligibilite ? $this->em->find(TestEligibiliteBrisPorte::class, $idTestEligibilite) : null;
     }
 
     protected function getDeclarationFDOEnCours(Request $request, Usager $requerant): ?DeclarationFDOBrisPorte

--- a/backend/src/Forms/TestEligibiliteBrisPorteType.php
+++ b/backend/src/Forms/TestEligibiliteBrisPorteType.php
@@ -3,14 +3,14 @@
 namespace MonIndemnisationJustice\Forms;
 
 use MonIndemnisationJustice\Entity\RapportAuLogement;
-use MonIndemnisationJustice\Entity\TestEligibilite;
+use MonIndemnisationJustice\Entity\TestEligibiliteBrisPorte;
 use MonIndemnisationJustice\Forms\Type\LiteralBooleanType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class TestEligibiliteType extends AbstractType
+class TestEligibiliteBrisPorteType extends AbstractType
 {
     public function getBlockPrefix(): string
     {
@@ -20,7 +20,7 @@ class TestEligibiliteType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'data_class' => TestEligibilite::class,
+            'data_class' => TestEligibiliteBrisPorte::class,
             'csrf_protection' => true,
             'csrf_field_name' => '_token',
             'csrf_token_id' => self::class,

--- a/backend/tests/Controller/BrisPorteControllerTest.php
+++ b/backend/tests/Controller/BrisPorteControllerTest.php
@@ -7,7 +7,7 @@ use MonIndemnisationJustice\Controller\BrisPorteController;
 use MonIndemnisationJustice\Entity\Agent;
 use MonIndemnisationJustice\Entity\DeclarationFDOBrisPorte;
 use MonIndemnisationJustice\Entity\RapportAuLogement;
-use MonIndemnisationJustice\Entity\TestEligibilite;
+use MonIndemnisationJustice\Entity\TestEligibiliteBrisPorte;
 use MonIndemnisationJustice\Entity\Usager;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -42,7 +42,7 @@ class BrisPorteControllerTest extends WebTestCase
     public function testTesterMonEligibilite(?callable $getTestEligibilite = null, ?string $redirection = null, bool $aRequerant = false): void
     {
         if ($getTestEligibilite) {
-            /** @var TestEligibilite $testEligibilite */
+            /** @var TestEligibiliteBrisPorte $testEligibilite */
             $testEligibilite = $getTestEligibilite($this->em);
             $this->initializeSession([BrisPorteController::CLEF_SESSION_TEST_ELIGIBILITE => $testEligibilite->id]);
         }
@@ -68,8 +68,8 @@ class BrisPorteControllerTest extends WebTestCase
         }
         $this->em->clear();
 
-        /** @var TestEligibilite $testEligibilite */
-        $testEligibilite = $this->em->getRepository(TestEligibilite::class)
+        /** @var TestEligibiliteBrisPorte $testEligibilite */
+        $testEligibilite = $this->em->getRepository(TestEligibiliteBrisPorte::class)
             ->createQueryBuilder('t')
             ->orderBy('t.dateSoumission', 'DESC')
             ->setMaxResults(1)
@@ -124,7 +124,7 @@ class BrisPorteControllerTest extends WebTestCase
     public function testCreationDeCompte(?callable $getTestEligibilite = null, ?string $redirection = null): void
     {
         if ($getTestEligibilite) {
-            /** @var TestEligibilite $testEligibilite */
+            /** @var TestEligibiliteBrisPorte $testEligibilite */
             $testEligibilite = $getTestEligibilite($this->em);
             $this->initializePreinscription($testEligibilite);
         }
@@ -180,7 +180,7 @@ class BrisPorteControllerTest extends WebTestCase
     public function testFinaliserLaCreation(?callable $getTestEligibilite = null, ?string $redirection = null): void
     {
         if ($getTestEligibilite) {
-            /** @var TestEligibilite $testEligibilite */
+            /** @var TestEligibiliteBrisPorte $testEligibilite */
             $testEligibilite = $getTestEligibilite($this->em);
             $this->initializePreinscription($testEligibilite);
         }
@@ -203,7 +203,7 @@ class BrisPorteControllerTest extends WebTestCase
         ];
     }
 
-    protected function initializePreinscription(?TestEligibilite $testEligibilite = null, ?DeclarationFDOBrisPorte $declarationErreurOperationnelle = null): void
+    protected function initializePreinscription(?TestEligibiliteBrisPorte $testEligibilite = null, ?DeclarationFDOBrisPorte $declarationErreurOperationnelle = null): void
     {
         $this->initializeSession([BrisPorteController::CLEF_SESSION_PREINSCRIPTION => [
             'testEligibilite' => $testEligibilite?->id,
@@ -231,7 +231,7 @@ class BrisPorteControllerTest extends WebTestCase
     protected static function getTestEligibiliteEnXpComplet(): callable
     {
         return function (EntityManagerInterface $em) {
-            $test = TestEligibilite::fromArray([
+            $test = TestEligibiliteBrisPorte::fromArray([
                 // 'description' => 'Test complet',
                 'estVise' => true,
                 'usager' => $em->getRepository(Usager::class)->findOneBy(['email' => 'raquel.randt@courriel.fr']),
@@ -247,7 +247,7 @@ class BrisPorteControllerTest extends WebTestCase
     protected static function getTestEligibiliteEnXpIncomplet(): callable
     {
         return function (EntityManagerInterface $em) {
-            $test = TestEligibilite::fromArray([
+            $test = TestEligibiliteBrisPorte::fromArray([
                 // 'description' => 'Test incomplet',
                 'estVise' => true,
                 'dateSoumission' => new \DateTimeImmutable()->modify('-2 minutes')]);

--- a/frontend/src/apps/requerant/dossier/components/TestEligibiliteBrisPorteForm.tsx
+++ b/frontend/src/apps/requerant/dossier/components/TestEligibiliteBrisPorteForm.tsx
@@ -27,7 +27,7 @@ const AvancementTest: LibelleAvancementTest[] = [
 
 type RapportAuLogementType = "proprietaire" | "locataire" | "bailleur";
 
-type TestEligibilite = {
+type TestEligibiliteBrisPorte = {
   avancement: LibelleAvancementTest;
   rapportAuLogement?: RapportAuLogementType;
   estVise?: boolean;
@@ -36,14 +36,14 @@ type TestEligibilite = {
   aContacteBailleur?: boolean;
 };
 
-export const TestEligibiliteForm = ({
+export const TestEligibiliteBrisPorteForm = ({
   token,
   estIssuAttestation,
 }: {
   token: string;
   estIssuAttestation: boolean;
 }) => {
-  const [test, setTest] = useState<TestEligibilite>({
+  const [test, setTest] = useState<TestEligibiliteBrisPorte>({
     avancement: "rapport_au_logement",
   });
 

--- a/frontend/src/apps/requerant/dossier/tester_mon_eligibilite.tsx
+++ b/frontend/src/apps/requerant/dossier/tester_mon_eligibilite.tsx
@@ -1,10 +1,10 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import { TestEligibiliteBrisPorteForm } from "@/apps/requerant/dossier/components/TestEligibiliteBrisPorteForm.tsx";
 import "@/style/requerant/dossier/test_mon_eligibilite.css";
-import { TestEligibiliteForm } from "@/apps/requerant/dossier/components/TestEligibiliteForm.tsx";
 import { Stepper } from "@codegouvfr/react-dsfr/Stepper";
 import { startReactDsfr } from "@codegouvfr/react-dsfr/spa";
 import { ColorScheme } from "@codegouvfr/react-dsfr/useIsDark";
+import React from "react";
+import ReactDOM from "react-dom/client";
 
 startReactDsfr({
   defaultColorScheme:
@@ -30,7 +30,7 @@ if (root) {
         />
 
         <div className="fr-col-12 fr-my-2w">
-          <TestEligibiliteForm
+          <TestEligibiliteBrisPorteForm
             token={args._token}
             estIssuAttestation={args.estIssuAttestation}
           />

--- a/frontend/src/common/models/Dossier.ts
+++ b/frontend/src/common/models/Dossier.ts
@@ -9,7 +9,7 @@ import { EtatDossier, EtatDossierType } from "./EtatDossier";
 import { TypeFDO } from "./InstitutionSecuritePublique";
 import { Redacteur } from "./Redacteur";
 import { Requerant } from "./Requerant";
-import { TestEligibilite } from "./TestEligibilite";
+import { TestEligibiliteBrisPorte } from "./TestEligibiliteBrisPorte.ts";
 import { Usager } from "./Usager";
 
 export type TypeAttestation =
@@ -146,8 +146,8 @@ export class DossierDetail extends BaseDossier {
   public readonly requerant: Requerant;
 
   @Expose()
-  @Type(() => TestEligibilite)
-  public readonly testEligibilite?: TestEligibilite;
+  @Type(() => TestEligibiliteBrisPorte)
+  public readonly testEligibilite?: TestEligibiliteBrisPorte;
 
   @Expose()
   @Type(() => DeclarationFDOBrisPorte)

--- a/frontend/src/common/models/TestEligibiliteBrisPorte.ts
+++ b/frontend/src/common/models/TestEligibiliteBrisPorte.ts
@@ -1,7 +1,7 @@
-import { RapportAuLogement } from "./RapportAuLogement";
 import { Transform } from "class-transformer";
+import { RapportAuLogement } from "./RapportAuLogement";
 
-export class TestEligibilite {
+export class TestEligibiliteBrisPorte {
   public estVise: boolean;
   public estHebergeant: boolean;
   @Transform(({ value }: { value: string }) => {

--- a/frontend/src/common/models/index.ts
+++ b/frontend/src/common/models/index.ts
@@ -11,7 +11,7 @@ import {
 
 import { Redacteur } from "./Redacteur";
 import { Requerant } from "./Requerant";
-import { TestEligibilite } from "./TestEligibilite";
+import { TestEligibiliteBrisPorte } from "./TestEligibiliteBrisPorte.ts";
 import { Usager } from "./Usager";
 
 export {
@@ -28,7 +28,7 @@ export {
   InstitutionSecuritePublique,
   Redacteur,
   Requerant,
-  TestEligibilite,
+  TestEligibiliteBrisPorte,
   TypeFDO,
   Usager,
 };


### PR DESCRIPTION
# Renommer le TestEligibilite actuel pour préciier qu'il concerne les bris de porte

En vue de faire la distinction avec celui créé par @Wafa-ba pour les dysfonctionnements

