### PR TITLE
Repasser par ProConnect lors de la déconnexion agent

### DIFF
--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -32,6 +32,7 @@ services:
       $clientId: '%env(PRO_CONNECT_CLIENT_ID)%'
       $clientSecret: '%env(PRO_CONNECT_CLIENT_SECRET)%'
       $loginCheckRoutes: [ 'securite_agent_connexion' ]
+      $logoutRoute: 'agent_securite_deconnexion'
       $context:
         scope: [ 'openid', 'given_name', 'usual_name', 'email', 'uid', 'siret', 'idp_id', 'custom' ]
 

--- a/backend/src/Api/Agent/Fip6/Endpoint/Agent/MoiEndpoint.php
+++ b/backend/src/Api/Agent/Fip6/Endpoint/Agent/MoiEndpoint.php
@@ -4,10 +4,13 @@ namespace MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Agent;
 
 use MonIndemnisationJustice\Api\Agent\Fip6\Output\AgentOutput;
 use MonIndemnisationJustice\Entity\Agent;
+use MonIndemnisationJustice\Security\Authenticator\ProConnectAuthenticator;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -18,12 +21,13 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 class MoiEndpoint
 {
     public function __construct(
-        protected readonly Security $security,
+        private readonly Security $security,
         private readonly NormalizerInterface $normalizer,
+        private readonly UrlGeneratorInterface $generateurUrl,
     ) {
     }
 
-    public function __invoke(): Response
+    public function __invoke(Request $request): Response
     {
         /** @var Agent $agentBetaIncarnant */
         $agentBetaIncarnant = null;
@@ -36,6 +40,9 @@ class MoiEndpoint
                 [
                     'agent' => AgentOutput::depuisAgent($this->security->getUser()),
                     'incarnePar' => $agentBetaIncarnant?->getNomComplet(true),
+                    'urlDeconnexion' => $agentBetaIncarnant ?
+                        $this->generateurUrl->generate('agent_fip6_react', ['extra' => '/agents/gestion?_switch_user=_exit'], UrlGeneratorInterface::ABSOLUTE_URL) :
+                        $request->getSession()->get(ProConnectAuthenticator::CLEF_SESSION_URL_DECONNEXION, $this->generateurUrl->generate('agent_securite_deconnexion', referenceType: UrlGeneratorInterface::ABSOLUTE_URL)),
                 ],
                 'json'
             )

--- a/backend/src/Api/Agent/Fip6/Endpoint/Agent/MoiEndpoint.php
+++ b/backend/src/Api/Agent/Fip6/Endpoint/Agent/MoiEndpoint.php
@@ -41,7 +41,7 @@ class MoiEndpoint
                     'agent' => AgentOutput::depuisAgent($this->security->getUser()),
                     'incarnePar' => $agentBetaIncarnant?->getNomComplet(true),
                     'urlDeconnexion' => $agentBetaIncarnant ?
-                        $this->generateurUrl->generate('agent_fip6_react', ['extra' => '/agents/gestion?_switch_user=_exit'], UrlGeneratorInterface::ABSOLUTE_URL) :
+                        $this->generateurUrl->generate('agent_fip6_react', ['extra' => 'agents/gestion', '_switch_user' => '_exit'], UrlGeneratorInterface::ABSOLUTE_URL) :
                         $request->getSession()->get(ProConnectAuthenticator::CLEF_SESSION_URL_DECONNEXION) ?? $this->generateurUrl->generate('agent_securite_deconnexion', referenceType: UrlGeneratorInterface::ABSOLUTE_URL),
                 ],
                 'json'

--- a/backend/src/Api/Agent/Fip6/Endpoint/Agent/MoiEndpoint.php
+++ b/backend/src/Api/Agent/Fip6/Endpoint/Agent/MoiEndpoint.php
@@ -42,7 +42,7 @@ class MoiEndpoint
                     'incarnePar' => $agentBetaIncarnant?->getNomComplet(true),
                     'urlDeconnexion' => $agentBetaIncarnant ?
                         $this->generateurUrl->generate('agent_fip6_react', ['extra' => '/agents/gestion?_switch_user=_exit'], UrlGeneratorInterface::ABSOLUTE_URL) :
-                        $request->getSession()->get(ProConnectAuthenticator::CLEF_SESSION_URL_DECONNEXION, $this->generateurUrl->generate('agent_securite_deconnexion', referenceType: UrlGeneratorInterface::ABSOLUTE_URL)),
+                        $request->getSession()->get(ProConnectAuthenticator::CLEF_SESSION_URL_DECONNEXION) ?? $this->generateurUrl->generate('agent_securite_deconnexion', referenceType: UrlGeneratorInterface::ABSOLUTE_URL),
                 ],
                 'json'
             )

--- a/backend/src/Controller/SecurityController.php
+++ b/backend/src/Controller/SecurityController.php
@@ -111,7 +111,6 @@ class SecurityController extends AbstractController
         return $this->redirectToRoute('securite_connexion');
     }
 
-    #[Route('/agent/connexion', name: 'agent_securite_connexion', methods: ['GET'])]
     #[IsGranted('PUBLIC_ACCESS')]
     #[Route('/connexion/agent', name: 'securite_agent_connexion', methods: ['GET', 'POST'])]
     public function connexionProConnect(Request $request, #[Autowire(service: 'oidc_client_pro_connect')] OidcClient $proConnectOidcClient): Response

--- a/backend/src/Security/Authenticator/FranceConnectAuthenticator.php
+++ b/backend/src/Security/Authenticator/FranceConnectAuthenticator.php
@@ -115,6 +115,7 @@ class FranceConnectAuthenticator extends AbstractAuthenticator
                 }
             }
 
+            // On prépare l'URL de déconnexion à partir du token ID
             $request->getSession()->set(self::LOGOUT_URL_SESSION_KEY, $this->oidcClient->buildLogoutUrl($request, $idToken));
 
             return new SelfValidatingPassport(new UserBadge($usager->getUserIdentifier()));

--- a/backend/src/Security/Authenticator/ProConnectAuthenticator.php
+++ b/backend/src/Security/Authenticator/ProConnectAuthenticator.php
@@ -25,6 +25,8 @@ use Symfony\Component\Security\Http\HttpUtils;
 
 class ProConnectAuthenticator extends AbstractAuthenticator implements AuthenticationEntryPointInterface
 {
+    public const CLEF_SESSION_URL_DECONNEXION = 'proconnect.url_deconnexion';
+
     public function __construct(
         protected readonly HttpUtils $httpUtils,
         #[Autowire(service: 'oidc_client_pro_connect')]
@@ -56,7 +58,7 @@ class ProConnectAuthenticator extends AbstractAuthenticator implements Authentic
     {
         try {
             // Authenticate
-            list($accessToken) = $this->oidcClient->authenticate($request);
+            list($accessToken, $idToken) = $this->oidcClient->authenticate($request);
 
             // User info
             $userInfo = $this->oidcClient->fetchUserInfo($accessToken);
@@ -123,6 +125,9 @@ class ProConnectAuthenticator extends AbstractAuthenticator implements Authentic
 
             $this->agentRepository->save($agent);
 
+            // On prépare l'URL de déconnexion à partir du token ID
+            $request->getSession()->set(self::CLEF_SESSION_URL_DECONNEXION, $this->oidcClient->buildLogoutUrl($request, $idToken));
+
             return new SelfValidatingPassport(new UserBadge($agent->getIdentifiant()));
         } catch (AuthenticationException $e) {
             $this->logger->error($e->getMessage(), $e->getMessageData());
@@ -138,7 +143,7 @@ class ProConnectAuthenticator extends AbstractAuthenticator implements Authentic
             return new RedirectResponse($redirection);
         }
 
-        // Sinon on renvoie vers la route d'accueil
+        // Sinon, on renvoie vers la route d'accueil
         return new RedirectResponse($this->urlGenerator->generate('agent_index'));
     }
 

--- a/backend/src/Security/Oidc/OidcClient.php
+++ b/backend/src/Security/Oidc/OidcClient.php
@@ -87,7 +87,7 @@ class OidcClient
 
     public function buildLogoutUrl(Request $request, string $idToken): ?string
     {
-        if (!isset($this->configuration['end_session_endpoint'])) {
+        if (!isset($this->configuration['end_session_endpoint']) || null === $this->logoutRoute) {
             return null;
         }
 

--- a/frontend/src/apps/_init.ts
+++ b/frontend/src/apps/_init.ts
@@ -1,3 +1,5 @@
+import "reflect-metadata";
+
 import { disableReactDevTools } from "@/apps/requerant/dossier/services/devtools";
 import * as Sentry from "@sentry/react";
 import "es-iterator-helpers/auto";

--- a/frontend/src/apps/agent/_commun/contexts/AgentContext.ts
+++ b/frontend/src/apps/agent/_commun/contexts/AgentContext.ts
@@ -3,4 +3,5 @@ import { Agent } from "@/common/models";
 export interface AgentContext {
   agent: Agent;
   incarnePar?: string;
+  urlDeconnexion: string;
 }

--- a/frontend/src/apps/agent/fdo/components/ModaleAjoutPieceJointe.tsx
+++ b/frontend/src/apps/agent/fdo/components/ModaleAjoutPieceJointe.tsx
@@ -175,7 +175,11 @@ export const ModaleAjoutPieceJointe = React.forwardRef<
           />
 
           <form.Subscribe
-            selector={(state) => [state.values.type, state.values.fichier]}
+            selector={(state) => [
+              state.values.type,
+              state.values.fichier,
+              state.isDirty,
+            ]}
             children={([type, fichier]) => (
               <ButtonsGroup
                 className="fr-col-12"

--- a/frontend/src/apps/agent/fdo/routes/__root.tsx
+++ b/frontend/src/apps/agent/fdo/routes/__root.tsx
@@ -110,9 +110,7 @@ const EspaceFDO = () => {
               "Déconnexion"
             ),
             linkProps: {
-              href: contexte.incarnePar
-                ? `${window.location.origin}/agent/fip6/agents/gestion?_switch_user=_exit`
-                : `${window.location.origin}/agent/deconnexion`,
+              href: contexte.urlDeconnexion,
               target: "_self",
             } as LinkProps,
           },

--- a/frontend/src/apps/agent/fip6/routes/__root.tsx
+++ b/frontend/src/apps/agent/fip6/routes/__root.tsx
@@ -1,21 +1,12 @@
 import { AgentContext } from "@/apps/agent/_commun/contexts/AgentContext.ts";
 import { container } from "@/apps/agent/fip6/container.ts";
-import {
-  CompteurDossiers,
-  DossierManagerInterface,
-} from "@/apps/agent/fip6/services/dossier.ts";
+import { CompteurDossiers, DossierManagerInterface } from "@/apps/agent/fip6/services/dossier.ts";
 import { RoleAgent } from "@/common/models/Agent.ts";
 import Badge from "@codegouvfr/react-dsfr/Badge";
 import Footer from "@codegouvfr/react-dsfr/Footer";
 import { Header } from "@codegouvfr/react-dsfr/Header";
 import Tooltip from "@codegouvfr/react-dsfr/Tooltip";
-import {
-  createRootRouteWithContext,
-  type LinkProps,
-  Outlet,
-  redirect,
-  useLoaderData,
-} from "@tanstack/react-router";
+import { createRootRouteWithContext, type LinkProps, Outlet, redirect, useLoaderData } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import * as React from "react";
 import { useMemo } from "react";
@@ -385,9 +376,7 @@ const EspaceRedacteur = () => {
               "Déconnexion"
             ),
             linkProps: {
-              href: contexte.incarnePar
-                ? `${window.location.origin}/agents/gestion?_switch_user=_exit`
-                : `${window.location.origin}/agent/deconnexion`,
+              href: contexte.urlDeconnexion,
               target: "_self",
             } as LinkProps,
           },

--- a/frontend/src/apps/agent/fip6/routes/__root.tsx
+++ b/frontend/src/apps/agent/fip6/routes/__root.tsx
@@ -1,12 +1,21 @@
 import { AgentContext } from "@/apps/agent/_commun/contexts/AgentContext.ts";
 import { container } from "@/apps/agent/fip6/container.ts";
-import { CompteurDossiers, DossierManagerInterface } from "@/apps/agent/fip6/services/dossier.ts";
+import {
+  CompteurDossiers,
+  DossierManagerInterface,
+} from "@/apps/agent/fip6/services/dossier.ts";
 import { RoleAgent } from "@/common/models/Agent.ts";
 import Badge from "@codegouvfr/react-dsfr/Badge";
 import Footer from "@codegouvfr/react-dsfr/Footer";
 import { Header } from "@codegouvfr/react-dsfr/Header";
 import Tooltip from "@codegouvfr/react-dsfr/Tooltip";
-import { createRootRouteWithContext, type LinkProps, Outlet, redirect, useLoaderData } from "@tanstack/react-router";
+import {
+  createRootRouteWithContext,
+  type LinkProps,
+  Outlet,
+  redirect,
+  useLoaderData,
+} from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import * as React from "react";
 import { useMemo } from "react";

--- a/frontend/src/common/services/agent/agent.ts
+++ b/frontend/src/common/services/agent/agent.ts
@@ -41,11 +41,14 @@ export class APIAgentManager implements AgentManagerInterface {
     if (!this._contexteNavigation) {
       const reponse = await fetch("/api/agent/fip6/moi");
 
-      const data: { agent: any; incarnePar: string } = await reponse.json();
+      const data: { agent: any; incarnePar: string; urlDeconnexion: string } =
+        await reponse.json();
 
       this._contexteNavigation = {
         agent: plainToInstance(Agent, data.agent),
         incarnePar: data.incarnePar,
+        urlDeconnexion:
+        data.urlDeconnexion,
       };
     }
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -33,5 +33,10 @@
     "src/style/**/*",
     "src/apps/_init.ts",
     "src/apps/sentry.ts",
+  ],
+  "references": [
+    { "path": "src/apps/agent/fdo" },
+    { "path": "src/apps/agent/fip6" },
+    { "path": "src/apps/requerant" }
   ]
 }


### PR DESCRIPTION
# Repasser par ProConnect lors de la déconnexion agent

Contrairement à FranceConnect, lorsqu'un agent se déconnecte, il n'est délogué que sur MIJ, pas sur ProConnect. Si bien que lorsqu'il essaie de se reconnecter il est automatiquement renvoyé sur MIJ, sans possibilité de remettre son mot de passe ou même de revoir la mire de consentement. Il faut donc attendre que la session expire sur ProConnect pour saisir à nouveau ses identifiants et passer le 2FA.

Ce correctif vise surtout à se ré-aligner avec le fonctionnement attendu.