### PR TITLE
Attraper, afficher et remonter les erreurs sur les espaces FIP6 et FDO

### DIFF
--- a/frontend/src/apps/agent/fdo/fdo.tsx
+++ b/frontend/src/apps/agent/fdo/fdo.tsx
@@ -1,5 +1,8 @@
 import "@/apps/_init.ts";
+import { ErreurComposant } from "@/common/composants/erreur/ErreurComposant";
+import { NonTrouveComposant } from "@/common/composants/erreur/NonTrouveComposant";
 import "@/style/agents.css";
+import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 import { startReactDsfr } from "@codegouvfr/react-dsfr/spa";
 import { ColorScheme } from "@codegouvfr/react-dsfr/useIsDark";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -33,7 +36,31 @@ createRoot(document.body).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <Provider container={container}>
-        <RouterProvider router={RouteurFDO} />
+        <RouterProvider
+          router={RouteurFDO}
+          defaultErrorComponent={({ error, info, reset }) => (
+            <ErreurComposant
+              erreur={error}
+              action={
+                <ButtonsGroup
+                  inlineLayoutWhen="always"
+                  alignment="center"
+                  buttonsIconPosition="left"
+                  buttonsEquisized={false}
+                  buttons={[
+                    {
+                      children: "Revenir à l'accueil",
+                      linkProps: {
+                        to: "/",
+                      },
+                    },
+                  ]}
+                />
+              }
+            />
+          )}
+          defaultNotFoundComponent={(props) => <NonTrouveComposant />}
+        />
       </Provider>
     </QueryClientProvider>
   </StrictMode>,

--- a/frontend/src/apps/agent/fdo/routeur/index.ts
+++ b/frontend/src/apps/agent/fdo/routeur/index.ts
@@ -2,8 +2,8 @@ import { AgentContext } from "@/apps/agent/_commun/contexts";
 import { AgentManagerInterface } from "@/common/services/agent/agent.ts";
 import * as Sentry from "@sentry/browser";
 import { createRouter } from "@tanstack/react-router";
-import { routeTree } from "./routeur-fdo.gen";
 import { container } from "../container";
+import { routeTree } from "./routeur-fdo.gen";
 
 const creerRouteurFDO = (context: AgentContext) =>
   createRouter({
@@ -11,6 +11,7 @@ const creerRouteurFDO = (context: AgentContext) =>
     defaultPreload: "intent",
     defaultStaleTime: 5000,
     scrollRestoration: true,
+    // Préfixage des URLS : le chemin /agent/fdo dans le navigateur pointe sur la racine du dossier "routes"
     rewrite: {
       // URL navigateur vers URL routeur
       input: ({ url }) => {

--- a/frontend/src/apps/agent/fdo/tsconfig.json
+++ b/frontend/src/apps/agent/fdo/tsconfig.json
@@ -1,4 +1,12 @@
 {
   "extends": "../../../../tsconfig.json",
-  "include": ["**/*"]
+  "include": [
+    "../../../../vite.config.ts",
+    "../../../../src/vite-env.d.ts",
+    "../../../../src/common/**/*",
+    "../../../../src/style/**/*",
+    "../../../../src/apps/_init.ts",
+    "../../../../src/apps/sentry.ts",
+    "**/*"
+  ]
 }

--- a/frontend/src/apps/agent/fip6/fip6.tsx
+++ b/frontend/src/apps/agent/fip6/fip6.tsx
@@ -8,8 +8,12 @@ import { queryClient } from "./query";
 
 import { container } from "./container";
 
+import { ErreurComposant } from "@/common/composants/erreur/ErreurComposant.tsx";
+import { NonTrouveComposant } from "@/common/composants/erreur/NonTrouveComposant.tsx";
+import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 import { startReactDsfr } from "@codegouvfr/react-dsfr/spa";
 import { ColorScheme } from "@codegouvfr/react-dsfr/useIsDark";
+import * as Sentry from "@sentry/react";
 import { Provider } from "inversify-react";
 import ReactDOM from "react-dom/client";
 import { RouteurFIP6 } from "./routeur";
@@ -32,7 +36,12 @@ declare module "@codegouvfr/react-dsfr/spa" {
   }
 }
 
-ReactDOM.createRoot(document.body).render(
+ReactDOM.createRoot(document.body, {
+  // Error reporting: captures all errors
+  onUncaughtError: Sentry.reactErrorHandler(),
+  onCaughtError: Sentry.reactErrorHandler(),
+  onRecoverableError: Sentry.reactErrorHandler(),
+}).render(
   <StrictMode>
     <CacheBuster
       currentAppVersion={import.meta.env.VITE_MIJ_VERSION || "dev"}
@@ -47,7 +56,31 @@ ReactDOM.createRoot(document.body).render(
     >
       <QueryClientProvider client={queryClient}>
         <Provider container={container}>
-          <RouterProvider router={RouteurFIP6} />
+          <RouterProvider
+            router={RouteurFIP6}
+            defaultErrorComponent={({ error, info, reset }) => (
+              <ErreurComposant
+                erreur={error}
+                action={
+                  <ButtonsGroup
+                    inlineLayoutWhen="always"
+                    alignment="center"
+                    buttonsIconPosition="left"
+                    buttonsEquisized={false}
+                    buttons={[
+                      {
+                        children: "Revenir à l'accueil",
+                        linkProps: {
+                          to: "/",
+                        },
+                      },
+                    ]}
+                  />
+                }
+              />
+            )}
+            defaultNotFoundComponent={(props) => <NonTrouveComposant />}
+          />
         </Provider>
       </QueryClientProvider>
     </CacheBuster>

--- a/frontend/src/apps/agent/fip6/routeur/index.ts
+++ b/frontend/src/apps/agent/fip6/routeur/index.ts
@@ -11,6 +11,7 @@ const creerRouteurFIP6 = (context: AgentContext) =>
     defaultPreload: "intent",
     defaultStaleTime: 5000,
     scrollRestoration: true,
+    // Préfixage des URLS : le chemin /agent/fip6 dans le navigateur pointe sur la racine du dossier "routes"
     rewrite: {
       // URL navigateur vers URL routeur
       input: ({ url }) => {

--- a/frontend/src/apps/agent/fip6/tsconfig.json
+++ b/frontend/src/apps/agent/fip6/tsconfig.json
@@ -1,4 +1,12 @@
 {
   "extends": "../../../../tsconfig.json",
-  "include": ["**/*"]
+  "include": [
+    "../../../../vite.config.ts",
+    "../../../../src/vite-env.d.ts",
+    "../../../../src/common/**/*",
+    "../../../../src/style/**/*",
+    "../../../../src/apps/_init.ts",
+    "../../../../src/apps/sentry.ts",
+    "**/*"
+  ]
 }

--- a/frontend/src/common/composants/erreur/ErreurComposant.tsx
+++ b/frontend/src/common/composants/erreur/ErreurComposant.tsx
@@ -32,19 +32,50 @@ export const ErreurComposant = ({
           <dt>Message</dt>
           <dd>{erreur.message}</dd>
 
-          <dt>Trace</dt>
-          <dd>
-            <pre>
-              <code>
-                {erreur.stack?.split("\n").map((ligne, i) => (
-                  <React.Fragment key={i}>
-                    {ligne}
-                    {"\n"}
-                  </React.Fragment>
-                ))}
-              </code>
-            </pre>
-          </dd>
+          {import.meta.env.DEV && (
+            <>
+              <dt>Trace</dt>
+              <dd>
+                <ul style={{ listStyle: "none" }}>
+                  {erreur.stack?.split("\n").map((entree, i) => {
+                    const [cible, chemin] = entree.split("@");
+                    const elements = chemin?.split(":");
+
+                    const url = elements?.slice(0, -2).join(":") || undefined;
+                    const ligne = elements?.at(-2) || undefined;
+                    const async = url?.startsWith("async*") || false;
+
+                    return (
+                      <li
+                        key={`stack-trace-ligne-${i}`}
+                        style={{
+                          padding: 0,
+                          margin: 0,
+                          fontFamily: "monospace",
+                          fontSize: ".7rem",
+                        }}
+                      >
+                        {url ? (
+                          <>
+                            <a href={url} style={{}}>
+                              {async && <>async </>}
+                              {cible.replace(/^async\*/, "")}
+                            </a>
+                            {ligne ? `,ligne ${ligne}` : ""}
+                          </>
+                        ) : (
+                          <span>
+                            {async && <>async </>}
+                            {cible.replace(/^async\*/, "")}
+                          </span>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </dd>
+            </>
+          )}
         </dl>
       </Accordion>
       {retour}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -64,7 +64,7 @@ export default defineConfig(({ mode }: UserConfig): UserConfig => {
       legacy({
         // Doc https://github.com/vitejs/vite/tree/main/packages/plugin-legacy
         //targets: ['defaults', 'not IE 11'],
-        modernTargets: ["firefox>=60, chrome>=61"],
+        modernTargets: ["firefox>=89", "chrome>=89"],
         polyfills: ["es.promise.finally", "es/map", "es/set", ""],
         modernPolyfills: true,
         renderLegacyChunks: false, // Pas besoin puisqu'on est ESM **only**
@@ -74,25 +74,30 @@ export default defineConfig(({ mode }: UserConfig): UserConfig => {
         stimulus: false,
       }),
       react(),
-      sentryVitePlugin({
-        org: "betagouv",
-        project: "mon-indemnisation-justice",
-        url: process.env.VITE_SENTRY_URL || "",
-        authToken: process.env.VITE_SENTRY_AUTH_TOKEN,
-        release: {
-          name: process.env.VITE_MIJ_VERSION || "dev",
-        },
-        sourcemaps: {
-          // As you're enabling client source maps, you probably want to delete them after they're uploaded to Sentry.
-          // Set the appropriate glob pattern for your output folder - some glob examples below:
-          filesToDeleteAfterUpload: [
-            "./**/*.map",
-            ".*/**/public/**/*.map",
-            "./dist/**/client/**/*.map",
-            "./build/**/client/**/*.map",
-          ],
-        },
-      }),
+      // Publication des sources vers Sentry (uniquement si l'env var VITE_SENTRY_AUTH_TOKEN est définie)
+      ...(process.env.VITE_SENTRY_AUTH_TOKEN
+        ? [
+            sentryVitePlugin({
+              org: "betagouv",
+              project: "mon-indemnisation-justice",
+              url: process.env.VITE_SENTRY_URL || "",
+              authToken: process.env.VITE_SENTRY_AUTH_TOKEN,
+              release: {
+                name: process.env.VITE_MIJ_VERSION || "dev",
+              },
+              sourcemaps: {
+                // As you're enabling client source maps, you probably want to delete them after they're uploaded to Sentry.
+                // Set the appropriate glob pattern for your output folder - some glob examples below:
+                filesToDeleteAfterUpload: [
+                  "./**/*.map",
+                  ".*/**/public/**/*.map",
+                  "./dist/**/client/**/*.map",
+                  "./build/**/client/**/*.map",
+                ],
+              },
+            }),
+          ]
+        : []),
     ],
     resolve: {
       alias: {


### PR DESCRIPTION
# Attraper, afficher et remonter les erreurs sur les espaces FIP6 et FDO

Aujourd'hui, lorsqu'une erreur technique survient sur l'espace FIP6 (i.e. l'espace rédacteur) et FDO, rien n'est remonté. À la place l'agent voir le message d'erreur par défaut de Tanstack Router.

L'objectif ici est d'aligner ça sur l'espace requérant.

Au passage : j'ai changé les `modernTargets` pour supprimer l'avertissement de `vite` sur les top level await.