### PR TITLE
Permettre au requérant de supprimer une pièce jointe de son dossier

### DIFF
--- a/backend/src/Api/Requerant/Dossier/Dto/DossierDto.php
+++ b/backend/src/Api/Requerant/Dossier/Dto/DossierDto.php
@@ -78,7 +78,6 @@ class DossierDto
             idDeclarationFDO: $dossier->getBrisPorte()->getDeclarationFDO()?->getId(),
             estPorteBlindee: $dossier->getBrisPorte()?->estPorteBlindee(),
             description: $dossier->getBrisPorte()->getDescriptionRequerant(),
-            // TODO gérer ça plus tard
             piecesJointes: $dossier->getPiecesJointes()->map(fn (Document $pieceJointe) => PieceJointeDto::depuisDocument($pieceJointe))->toArray(),
         );
     }

--- a/backend/src/Api/Requerant/PieceJointe/SupprimerPieceJointeEndpoint.php
+++ b/backend/src/Api/Requerant/PieceJointe/SupprimerPieceJointeEndpoint.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MonIndemnisationJustice\Api\Requerant\PieceJointe;
+
+use MonIndemnisationJustice\Api\Requerant\Dossier\Dto\DossierDto;
+use MonIndemnisationJustice\Api\Requerant\Voter\RequerantDossierVoter;
+use MonIndemnisationJustice\Entity\Document;
+use MonIndemnisationJustice\Service\DocumentManager;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+#[Route('/api/requerant/piece-jointe/{id}/supprimer', name: 'api_requerant_piece_jointe_supprimer', methods: ['DELETE'])]
+#[IsGranted(RequerantDossierVoter::ACTION_DOSSIER_SUPPRIMER_PIECE_JOINTE, 'pieceJointe', message: 'Seul le requérant peut supprimer une pièce jointe de son dossier', statusCode: Response::HTTP_FORBIDDEN)]
+class SupprimerPieceJointeEndpoint
+{
+    public function __invoke(
+        #[MapEntity]
+        Document $pieceJointe,
+        DocumentManager $documentManager,
+        NormalizerInterface $normalizer,
+    ) {
+        $documentManager->supprimer($pieceJointe);
+
+        return new JsonResponse(
+            $normalizer->normalize(DossierDto::depuisDossier($pieceJointe->getDossier()), 'json'),
+            Response::HTTP_OK
+        );
+    }
+}

--- a/backend/src/Api/Requerant/Voter/RequerantDossierVoter.php
+++ b/backend/src/Api/Requerant/Voter/RequerantDossierVoter.php
@@ -2,6 +2,7 @@
 
 namespace MonIndemnisationJustice\Api\Requerant\Voter;
 
+use MonIndemnisationJustice\Entity\Document;
 use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\Usager;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -15,6 +16,7 @@ class RequerantDossierVoter extends Voter
     public const string ACTION_DOSSIER_CONSULTER = 'dossier:consulter';
     public const string ACTION_DOSSIER_AMENDER = 'dossier:amender';
     public const string ACTION_DOSSIER_TELEVERSER = 'dossier:televerser';
+    public const string ACTION_DOSSIER_SUPPRIMER_PIECE_JOINTE = 'dossier:supprimer-piece-jointe';
     public const string ACTION_DOSSIER_PUBLIER = 'dossier:publier';
     public const string ACTION_DOSSIER_ACCEPTER_INDEMNISATION = 'dossier:accepter_indemnisation';
 
@@ -28,6 +30,7 @@ class RequerantDossierVoter extends Voter
                 self::ACTION_DOSSIER_CONSULTER,
                 self::ACTION_DOSSIER_AMENDER,
                 self::ACTION_DOSSIER_TELEVERSER,
+                self::ACTION_DOSSIER_SUPPRIMER_PIECE_JOINTE,
                 self::ACTION_DOSSIER_PUBLIER,
                 self::ACTION_DOSSIER_ACCEPTER_INDEMNISATION,
             ]
@@ -45,6 +48,17 @@ class RequerantDossierVoter extends Voter
 
         if (in_array($attribute, [self::ACTION_DOSSIER_LISTER, self::ACTION_DOSSIER_INITIER])) {
             return true;
+        }
+
+        if (self::ACTION_DOSSIER_SUPPRIMER_PIECE_JOINTE === $attribute) {
+            if (!$subject instanceof Document) {
+                return false;
+            }
+            /** @var Document $pieceJointe */
+            $pieceJointe = $subject;
+
+            // La pièce jointe est lié au dossier du requérant
+            return $pieceJointe->getDossier()->getUsager() === $usager;
         }
 
         // Les actions de consultation / édition, liée à un dossier spécifique, sont restreintes à l'usager l'ayant initié

--- a/backend/src/Entity/Dossier.php
+++ b/backend/src/Entity/Dossier.php
@@ -530,6 +530,15 @@ class Dossier
         return $document ?? new Document()->setType($type)->ajouterAuDossier($this);
     }
 
+    public function retirerPieceJointe(Document $pieceJointe): self
+    {
+        $this->piecesJointes->removeElement($pieceJointe);
+        // On réordonne les pièces jointes pour que les indices soient cohérents
+        $this->piecesJointes = new ArrayCollection($this->piecesJointes->getValues());
+
+        return $this;
+    }
+
     /**
      * @param bool|null $progression est-ce qu'il s'agit d'une avancée d'un état vers le suivant ou d'un retour arrière ?
      *

--- a/backend/src/Repository/DossierRepository.php
+++ b/backend/src/Repository/DossierRepository.php
@@ -3,6 +3,7 @@
 namespace MonIndemnisationJustice\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Persistence\ManagerRegistry;
 use MonIndemnisationJustice\Entity\Agent;
@@ -136,17 +137,30 @@ class DossierRepository extends ServiceEntityRepository
         return $this->listerDossierParEtat(EtatDossierType::DOSSIER_OK_A_INDEMNISER);
     }
 
-    /**
-     * @return Dossier[]
-     */
-    public function listerDossierParEtat(EtatDossierType $etat): array
+    protected function creerBaseRequeteDossierParEtat(EtatDossierType $etat, DossierType $type = DossierType::BRIS_PORTE): QueryBuilder
     {
         return $this->createQueryBuilder('d')
             ->join('d.etatDossier', 'ed')
             ->where('ed.etat = :etat')
+            ->andWhere('d.type = :type')
             ->setParameter('etat', $etat)
+            ->setParameter('type', $type);
+    }
+
+    public function getDossierParEtat(EtatDossierType $etat, DossierType $type = DossierType::BRIS_PORTE): ?Dossier
+    {
+        return $this->creerBaseRequeteDossierParEtat($etat, $type)
             ->getQuery()
-            ->getResult();
+            ->setMaxResults(1)
+            ->getSingleResult();
+    }
+
+    /**
+     * @return Dossier[]
+     */
+    public function listerDossierParEtat(EtatDossierType $etat, DossierType $type = DossierType::BRIS_PORTE): array
+    {
+        return $this->creerBaseRequeteDossierParEtat($etat, $type)->getQuery()->getResult();
     }
 
     /**

--- a/backend/src/Service/DocumentManager.php
+++ b/backend/src/Service/DocumentManager.php
@@ -7,9 +7,9 @@ use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\UnableToReadFile;
 use League\Flysystem\UnableToWriteFile;
-use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\Document;
 use MonIndemnisationJustice\Entity\DocumentType;
+use MonIndemnisationJustice\Entity\Dossier;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\Filesystem\Path;
@@ -100,6 +100,7 @@ class DocumentManager
     public function supprimer(Document $document)
     {
         $this->storage->delete($document->getFilename());
+        $document->getDossier()->retirerPieceJointe($document);
 
         $this->em->remove($document);
         $this->em->flush();

--- a/backend/tests/Api/Requerant/Dossier/TeleverserPiecesJointesEndpointTest.php
+++ b/backend/tests/Api/Requerant/Dossier/TeleverserPiecesJointesEndpointTest.php
@@ -3,7 +3,7 @@
 namespace MonIndemnisationJustice\Tests\Api\Requerant\Dossier;
 
 use Doctrine\ORM\EntityManagerInterface;
-use MonIndemnisationJustice\Api\Requerant\Dossier\AmenderDossierEndpoint;
+use MonIndemnisationJustice\Api\Requerant\Dossier\TeleverserPiecesJointesEndpoint;
 use MonIndemnisationJustice\Entity\DocumentType;
 use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\DossierType;
@@ -14,7 +14,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-#[CoversClass(AmenderDossierEndpoint::class)]
+#[CoversClass(TeleverserPiecesJointesEndpoint::class)]
 class TeleverserPiecesJointesEndpointTest extends WebTestCase
 {
     protected KernelBrowser $client;

--- a/backend/tests/Api/Requerant/PieceJointe/SupprimerPieceJointeEndpointTest.php
+++ b/backend/tests/Api/Requerant/PieceJointe/SupprimerPieceJointeEndpointTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Api\Requerant\PieceJointe;
+
+use Doctrine\ORM\EntityManagerInterface;
+use MonIndemnisationJustice\Api\Requerant\PieceJointe\SupprimerPieceJointeEndpoint;
+use MonIndemnisationJustice\Entity\Document;
+use MonIndemnisationJustice\Entity\Dossier;
+use MonIndemnisationJustice\Entity\DossierType;
+use MonIndemnisationJustice\Entity\EtatDossierType;
+use MonIndemnisationJustice\Entity\Usager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversClass(SupprimerPieceJointeEndpoint::class)]
+class SupprimerPieceJointeEndpointTest extends WebTestCase
+{
+    protected KernelBrowser $client;
+    protected EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = self::createClient(['debug' => true]);
+        $this->em = self::getContainer()->get(EntityManagerInterface::class);
+    }
+
+    public function testSupprimerPieceJointeOk()
+    {
+
+        /** @var Dossier $dossier */
+        $dossier = $this->em->getRepository(Dossier::class)->getDossierParEtat(EtatDossierType::DOSSIER_A_ATTRIBUER, DossierType::BRIS_PORTE);
+        $usager = $dossier->getUsager();
+        $nbPiecesJointes = $dossier->getPiecesJointes()->count();
+        /** @var Document $pieceJointe */
+        $pieceJointe = $dossier->getPiecesJointes()->first();
+        $this->client->loginUser($usager, 'requerant');
+
+        $this->client->request(
+            'DELETE',
+            "/api/requerant/piece-jointe/{$pieceJointe->getId()}/supprimer",
+        );
+
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $donnees = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertCount($nbPiecesJointes - 1, $donnees['piecesJointes']);
+
+        $this->em->refresh($dossier);
+
+        $this->assertCount($nbPiecesJointes - 1, $dossier->getPiecesJointes());
+        $this->assertEmpty($dossier->getPiecesJointes()->filter(fn (Document $pj) => $pj->getId() === $pieceJointe->getId())->toArray());
+    }
+
+    /**
+     * ETQ requérant, je ne dois pas pouvoir supprimer la pièce jointe d'un dossier qui n'est pas à moi.
+     */
+    public function testSupprimerPieceJointeKoPasMonDossier(): void
+    {
+        /** @var Dossier $dossier */
+        $dossier = $this->em->getRepository(Dossier::class)->getDossierParEtat(EtatDossierType::DOSSIER_A_ATTRIBUER, DossierType::BRIS_PORTE);
+        $proprietaire = $dossier->getUsager();
+        /** @var Document $pieceJointe */
+        $pieceJointe = $dossier->getPiecesJointes()->first();
+
+        // Recherchons un usager autre que le propriétaire du dossier
+        $autresUsagers = $this->em->getRepository(Usager::class)
+            ->createQueryBuilder('u')
+            ->where('u.id != :id')
+            ->setParameter('id', $proprietaire->getId())
+            ->getQuery()
+            ->getResult();
+        $usager = $autresUsagers[random_int(0, count($autresUsagers) - 1)];
+
+        $this->client->loginUser($usager, 'requerant');
+
+        $this->client->request(
+            'DELETE',
+            "/api/requerant/piece-jointe/{$pieceJointe->getId()}/supprimer",
+        );
+
+        $this->assertEquals(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
+
+        $donnees = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('Seul le requérant peut supprimer une pièce jointe de son dossier', $donnees['erreur']);
+    }
+}

--- a/frontend/src/apps/agent/fip6/routeur/index.ts
+++ b/frontend/src/apps/agent/fip6/routeur/index.ts
@@ -48,6 +48,7 @@ await container
 
 declare module "@tanstack/react-router" {
   interface Register {
+    // @ts-expect-error: chaque app déclare son propre router localement
     router: ReturnType<typeof creerRouteurFIP6>;
   }
 

--- a/frontend/src/apps/requerant/composants/piecesJointes/SupprimerPieceJointeModale.tsx
+++ b/frontend/src/apps/requerant/composants/piecesJointes/SupprimerPieceJointeModale.tsx
@@ -1,0 +1,89 @@
+import { AfficherPieceJointe } from "@/apps/requerant/dossier/components/PieceJointe/AfficherPieceJointe";
+import { PieceJointe } from "@/apps/requerant/models";
+import {
+  Modale,
+  ModaleProps,
+  ModaleRef,
+} from "@/common/composants/dsfr/Modale.tsx";
+import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
+import React, {
+  ForwardedRef,
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+} from "react";
+
+export type SupprimerPiecesJointesModaleRef = {
+  ouvrir: () => void;
+  fermer: () => void;
+};
+
+export type SupprimerPiecesJointesModaleProps = Omit<
+  ModaleProps,
+  "children" | "id" | "title" | "titleProps" | "titleAs"
+> & {
+  pieceJointe: PieceJointe;
+  onConfirme: (pieceJointe: PieceJointe) => Promise<void>;
+};
+
+export const SupprimerPieceJointeModale = forwardRef<
+  SupprimerPiecesJointesModaleRef,
+  SupprimerPiecesJointesModaleProps
+>(
+  (
+    { pieceJointe, onConfirme, ...props }: SupprimerPiecesJointesModaleProps,
+    ref: ForwardedRef<SupprimerPiecesJointesModaleRef>,
+  ) => {
+    const refModale = useRef<ModaleRef>(null);
+
+    const fermer = () => {
+      refModale.current?.fermer();
+    };
+
+    useImperativeHandle(ref, () => ({
+      ouvrir: () => {
+        refModale.current?.ouvrir();
+      },
+      fermer: () => {
+        refModale.current?.fermer();
+      },
+    }));
+
+    return (
+      <Modale
+        {...props}
+        title="Supprimer la pièce jointe"
+        id="supprimer-piece-jointe-modale"
+        ref={refModale}
+        size="large"
+      >
+        <p>
+          Vous souhaitez supprimer la pièce jointe "{pieceJointe.nom}" de type{" "}
+          {pieceJointe.type.libelle({ enCapitales: false, court: true })},
+          confirmez-vous ?
+        </p>
+        <AfficherPieceJointe pieceJointe={pieceJointe} />
+
+        <ButtonsGroup
+          inlineLayoutWhen="always"
+          alignment="right"
+          buttonsIconPosition="right"
+          buttonsSize="small"
+          buttons={[
+            {
+              priority: "secondary",
+              children: "Annuler",
+              onClick: () => refModale.current?.fermer(),
+            },
+            {
+              priority: "primary",
+              children: "Confirmer",
+              iconId: "fr-icon-delete-line",
+              onClick: () => onConfirme(pieceJointe),
+            },
+          ]}
+        />
+      </Modale>
+    );
+  },
+);

--- a/frontend/src/apps/requerant/dossier/components/PieceJointe/AfficherPieceJointe.tsx
+++ b/frontend/src/apps/requerant/dossier/components/PieceJointe/AfficherPieceJointe.tsx
@@ -1,26 +1,71 @@
+import {
+  SupprimerPieceJointeModale,
+  SupprimerPiecesJointesModaleRef,
+} from "@/apps/requerant/composants/piecesJointes/SupprimerPieceJointeModale";
 import { PieceJointe } from "@/apps/requerant/models";
 import { DocumentPDF } from "@/common/composants/document/DocumentPDF.tsx";
+import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 import Download from "@codegouvfr/react-dsfr/Download";
-import { default as React } from "react";
+import { default as React, useRef } from "react";
 
 export const AfficherPieceJointe = ({
   pieceJointe,
   telecharger = true,
+  supprimer = undefined,
 }: {
   pieceJointe: PieceJointe;
   telecharger?: boolean;
+  supprimer?: (pieceJointe: PieceJointe) => void | Promise<void> | undefined;
 }) => {
+  // La référence vers la modale de suppression de pièce jointe
+  const refModaleSuppressionPieceJointe =
+    useRef<SupprimerPiecesJointesModaleRef>(null);
+
   return (
     <>
-      {telecharger && (
-        <Download
-          className="fr-col-12"
-          details={`${pieceJointe.infoFichier}`}
-          label={pieceJointe.nom}
-          linkProps={{
-            href: `${pieceJointe.url}?download`,
+      {supprimer && (
+        <SupprimerPieceJointeModale
+          ref={refModaleSuppressionPieceJointe}
+          pieceJointe={pieceJointe}
+          onConfirme={async () => {
+            await supprimer(pieceJointe);
+            refModaleSuppressionPieceJointe.current?.fermer();
           }}
         />
+      )}
+
+      {(telecharger || supprimer) && (
+        <div className="fr-grid-row fr-col-12">
+          {telecharger && (
+            <Download
+              className="fr-col-6"
+              details={`${pieceJointe.infoFichier}`}
+              label={pieceJointe.nom}
+              linkProps={{
+                href: `${pieceJointe.url}?download`,
+              }}
+            />
+          )}
+
+          {supprimer && (
+            <ButtonsGroup
+              className={telecharger ? "fr-col-6" : "fr-col-12"}
+              inlineLayoutWhen="always"
+              alignment="right"
+              buttonsIconPosition="right"
+              buttonsSize="small"
+              buttons={[
+                {
+                  children: "Supprimer cette pièce jointe",
+                  iconId: "fr-icon-delete-line",
+                  priority: "tertiary no outline",
+                  onClick: () =>
+                    refModaleSuppressionPieceJointe.current?.ouvrir(),
+                },
+              ]}
+            />
+          )}
+        </div>
       )}
 
       {pieceJointe.estPDF() ? (

--- a/frontend/src/apps/requerant/routes/requerant/dossier/bris-de-porte/$id/1-bris-porte.tsx
+++ b/frontend/src/apps/requerant/routes/requerant/dossier/bris-de-porte/$id/1-bris-porte.tsx
@@ -6,7 +6,7 @@ import { TitreSection } from "@/apps/requerant/composants/TitreSection.tsx";
 import { container } from "@/apps/requerant/container.ts";
 import {
   extraireDonneesBrisDeporte,
-  SchemaValidationBrisPorte
+  SchemaValidationBrisPorte,
 } from "@/apps/requerant/formulaires/brisDePorte/1-bris-porte.schema";
 import {
   Adresse,
@@ -15,7 +15,7 @@ import {
   getRapportAuLogementLibelle,
   RapportAuLogement,
   TypePersonneMoraleType,
-  TypesPersonneMorale
+  TypesPersonneMorale,
 } from "@/apps/requerant/models";
 import { RapportAuLogements } from "@/apps/requerant/models/RapportAuLogement.ts";
 import { RouteurRequerant } from "@/apps/requerant/routeur";
@@ -30,7 +30,13 @@ import Notice from "@codegouvfr/react-dsfr/Notice";
 import { RadioButtons } from "@codegouvfr/react-dsfr/RadioButtons";
 import { Stepper } from "@codegouvfr/react-dsfr/Stepper";
 import { useForm } from "@tanstack/react-form";
-import { createFileRoute, notFound, redirect, useBlocker, useNavigate } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  notFound,
+  redirect,
+  useBlocker,
+  useNavigate,
+} from "@tanstack/react-router";
 import { useInjection } from "inversify-react";
 import React, { useState } from "react";
 
@@ -187,11 +193,11 @@ function Etape1BrisPorte() {
           {dossier.estEnInstruction && (
             <div className="fr-grid-row">
               <Notice
-                description="Cette étape est en lecture seule le dossier étant entré en instruction"
+                description="Le dossier étant entré en instruction, vous ne pouvez pas modifier les informations"
                 iconDisplayed
                 isClosable={false}
                 severity="info"
-                title="Cette étape est en lecture seule, le dossier étant entré en instruction"
+                title="Cette étape est en lecture seule"
               />
             </div>
           )}

--- a/frontend/src/apps/requerant/routes/requerant/dossier/bris-de-porte/$id/2-infos-requerant.tsx
+++ b/frontend/src/apps/requerant/routes/requerant/dossier/bris-de-porte/$id/2-infos-requerant.tsx
@@ -192,11 +192,11 @@ function Etape2InfosRequerant() {
           {dossier.estEnInstruction && (
             <div className="fr-grid-row">
               <Notice
-                description="Cette étape est en lecture seule le dossier étant entré en instruction"
+                description="Le dossier étant entré en instruction, vous ne pouvez pas modifier les informations"
                 iconDisplayed
                 isClosable={false}
                 severity="info"
-                title="Cette étape est en lecture seule, le dossier étant entré en instruction"
+                title="Cette étape est en lecture seule"
               />
             </div>
           )}

--- a/frontend/src/apps/requerant/routes/requerant/dossier/bris-de-porte/$id/3-pieces-jointes.tsx
+++ b/frontend/src/apps/requerant/routes/requerant/dossier/bris-de-porte/$id/3-pieces-jointes.tsx
@@ -393,6 +393,20 @@ function Etape3PiecesJointes() {
                               dossier.id,
                               pieceJointe,
                             );
+                            // Sélection de la pièce jointe précédente
+                            const index =
+                              dossier.piecesJointes.indexOf(pieceJointe);
+                            if (index >= 0) {
+                              selectionnerPieceJointe(
+                                dossier.piecesJointes.at(index - 1),
+                              );
+                              selectionnerTypePieceJointe(
+                                dossier.piecesJointes.at(index - 1)?.type ||
+                                  (typesPiecesJointesDemandes.at(
+                                    0,
+                                  ) as TypePieceJointe),
+                              );
+                            }
                             await (
                               routeur as typeof RouteurRequerant
                             ).invalidate();

--- a/frontend/src/apps/requerant/routes/requerant/dossier/bris-de-porte/$id/3-pieces-jointes.tsx
+++ b/frontend/src/apps/requerant/routes/requerant/dossier/bris-de-porte/$id/3-pieces-jointes.tsx
@@ -106,7 +106,7 @@ function Etape3PiecesJointes() {
   const { dossier }: { dossier: Dossier } = Route.useLoaderData();
 
   // Récupération du routeur, uniquement pour pouvoir invalider son cache
-  const routeur = useRouter();
+  const routeur = useRouter<typeof RouteurRequerant>();
 
   // La référence vers la modale d'ajout de pièce jointe
   const refModaleAjoutPieceJointe = useRef<AjouterPiecesJointesModaleRef>(null);
@@ -383,7 +383,23 @@ function Etape3PiecesJointes() {
                       : ["fr-hidden" as FrCxArg]),
                   ])}
                 >
-                  <AfficherPieceJointe pieceJointe={pieceJointe} />
+                  <AfficherPieceJointe
+                    pieceJointe={pieceJointe}
+                    supprimer={
+                      pieceJointeSelectionnee &&
+                      pieceJointeSelectionnee.id == pieceJointe.id
+                        ? async (pieceJointe: PieceJointe) => {
+                            await dossierManager.retirerPieceJointe(
+                              dossier.id,
+                              pieceJointe,
+                            );
+                            await (
+                              routeur as typeof RouteurRequerant
+                            ).invalidate();
+                          }
+                        : undefined
+                    }
+                  />
                 </div>
               ))}
 

--- a/frontend/src/apps/requerant/services/DossierManager.ts
+++ b/frontend/src/apps/requerant/services/DossierManager.ts
@@ -1,4 +1,4 @@
-import { Dossier } from "@/apps/requerant/models";
+import { Dossier, PieceJointe } from "@/apps/requerant/models";
 import { DossierApercu } from "@/apps/requerant/models/Dossier.ts";
 import { TypePieceJointe } from "@/apps/requerant/models/TypePieceJointe.ts";
 import { differentiel } from "@/common/services";
@@ -38,6 +38,11 @@ export interface DossierManagerInterface {
     id: number,
     piecesJointes: NouvellePieceJointe[],
   ): Promise<Dossier | undefined>;
+
+  retirerPieceJointe(
+    dossierId: number,
+    pieceJointe: PieceJointe,
+  ): Promise<boolean>;
 
   mesDemandes(): Promise<DossierApercu[]>;
 
@@ -142,6 +147,14 @@ export class ApiDossierManager implements DossierManagerInterface {
     });
 
     return this.dossiers.get(id)?.modifie;
+  }
+
+  retirerPieceJointe(
+    dossierId: number,
+    pieceJointe: PieceJointe,
+  ): Promise<boolean> {
+    // TODO implémenter l'appel à l'API
+    return Promise.resolve(true);
   }
 
   async enregistrer(id: number): Promise<Dossier> {

--- a/frontend/src/apps/requerant/services/DossierManager.ts
+++ b/frontend/src/apps/requerant/services/DossierManager.ts
@@ -149,12 +149,26 @@ export class ApiDossierManager implements DossierManagerInterface {
     return this.dossiers.get(id)?.modifie;
   }
 
-  retirerPieceJointe(
+  async retirerPieceJointe(
     dossierId: number,
     pieceJointe: PieceJointe,
   ): Promise<boolean> {
-    // TODO implémenter l'appel à l'API
-    return Promise.resolve(true);
+    const reponse = await fetch(
+      `/api/requerant/piece-jointe/${pieceJointe.id}/supprimer`,
+      {
+        method: "DELETE",
+      },
+    );
+
+    const data = await reponse.json();
+    const dossier = plainToInstance(Dossier, data);
+
+    this.dossiers.set(dossier.id, {
+      original: dossier,
+      modifie: instanceToInstance(dossier),
+    });
+
+    return reponse.ok;
   }
 
   async enregistrer(id: number): Promise<Dossier> {


### PR DESCRIPTION
# Permettre au requérant de supprimer une pièce jointe de son dossier

Jusqu'ici un requérant pouvait ajouter une pièce jointe, en la prévisualisant au préalable, mais ne pouvait pas la supprimer.

C'est donc chose faite ici, avec le point d'entrée API idoine.