### PR TITLE
Ajouter l'option bailleur social au test d'éligibilité

### DIFF
--- a/backend/src/Api/Requerant/Dossier/Dto/DossierDto.php
+++ b/backend/src/Api/Requerant/Dossier/Dto/DossierDto.php
@@ -4,7 +4,6 @@ namespace MonIndemnisationJustice\Api\Requerant\Dossier\Dto;
 
 use MonIndemnisationJustice\Entity\Document;
 use MonIndemnisationJustice\Entity\Dossier;
-use MonIndemnisationJustice\Entity\PersonnePhysique;
 use MonIndemnisationJustice\Entity\RapportAuLogement;
 use Symfony\Component\Serializer\Attribute\Context;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
@@ -67,7 +66,7 @@ class DossierDto
             etatActuel: EtatDossierDto::depuisEtatDossier($dossier->getEtatDossier()),
             dateDepot: $dossier->getDateDepot() ? \DateTimeImmutable::createFromInterface($dossier->getDateDepot()) : null,
             estPersonneMorale: $dossier->estPersonneMorale(),
-            personnePhysique: PersonnePhysiqueDto::depuisPersonnePhysique($dossier->getRequerantPersonnePhysique() ?? $dossier->getUsager()->getPersonne()->getPersonnePhysique() ?? new PersonnePhysique()),
+            personnePhysique: PersonnePhysiqueDto::depuisPersonnePhysique($dossier->getRequerantPersonnePhysique() ?? $dossier->getUsager()->getPersonne()->getPersonnePhysique()),
             personneMorale: PersonneMoraleDto::depuisPersonneMorale($dossier->getRequerantPersonneMorale()),
             rapportAuLogement: $dossier->getBrisPorte()->getRapportAuLogement(),
             descriptionRapportAuLogement: $dossier->getBrisPorte()->getPrecisionRapportAuLogement(),

--- a/backend/src/Api/Requerant/Dossier/Dto/PersonnePhysiqueDto.php
+++ b/backend/src/Api/Requerant/Dossier/Dto/PersonnePhysiqueDto.php
@@ -44,7 +44,7 @@ class PersonnePhysiqueDto
         }
 
         return new self(
-            personne: PersonneDto::depuisPersonne($personnePhysique->getPersonne()),
+            personne: $personnePhysique->getPersonne() ? PersonneDto::depuisPersonne($personnePhysique->getPersonne()) : null,
             prenom2: $personnePhysique->getPrenom2(),
             prenom3: $personnePhysique->getPrenom3(),
             adresse: AdresseDto::depuisAdresse($personnePhysique->getAdresse()),

--- a/backend/src/Controller/BrisPorteController.php
+++ b/backend/src/Controller/BrisPorteController.php
@@ -10,6 +10,7 @@ use MonIndemnisationJustice\Entity\DeclarationFDOBrisPorte;
 use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\Metadonnees\NavigationRequerant;
 use MonIndemnisationJustice\Entity\Personne;
+use MonIndemnisationJustice\Entity\RapportAuLogement;
 use MonIndemnisationJustice\Entity\TestEligibiliteBrisPorte;
 use MonIndemnisationJustice\Entity\Usager;
 use MonIndemnisationJustice\Forms\TestEligibiliteBrisPorteType;
@@ -194,6 +195,7 @@ class BrisPorteController extends AbstractController
                 ],
                 'token' => $csrfTokenManager->getToken('creation-de-compte')->getValue(),
                 'inscription' => $normalizer->normalize($inscription, 'json'),
+                'franceConnect' => !(RapportAuLogement::BAILLEUR_SOCIAL === $preinscription->testEligibilite?->rapportAuLogement),
             ],
         ]);
     }

--- a/backend/src/Entity/Dossier.php
+++ b/backend/src/Entity/Dossier.php
@@ -572,12 +572,16 @@ class Dossier
         return Dossier::brisDePorte()
             ->setUsager($testEligibilite->usager)
             ->setRequerant(
-
-                // Si l'usager a déjà une personne physique associée, on utilise celle-ci
-                $testEligibilite->usager->getPersonne()->getPersonnePhysique() ??
-                new PersonnePhysique()
-                    ->setPersonne($testEligibilite->usager->getPersonne())
+                RapportAuLogement::BAILLEUR_SOCIAL === $testEligibilite->rapportAuLogement ?
+                    new PersonneMorale()
+                        ->setRepresentantLegal($testEligibilite->usager->getPersonne())
+                        ->setType(PersonneMoraleType::BAILLEUR_SOCIAL) :
+                    // Si l'usager a déjà une personne physique associée, on utilise celle-ci
+                    $testEligibilite->usager->getPersonne()->getPersonnePhysique() ??
+                    new PersonnePhysique()
+                        ->setPersonne($testEligibilite->usager->getPersonne())
             )
+            ->setPersonneMorale(RapportAuLogement::BAILLEUR_SOCIAL === $testEligibilite->rapportAuLogement)
             ->setBrisPorte(
                 new BrisPorte()
                     ->setRapportAuLogement($testEligibilite->rapportAuLogement)

--- a/backend/src/Entity/RapportAuLogement.php
+++ b/backend/src/Entity/RapportAuLogement.php
@@ -7,6 +7,7 @@ enum RapportAuLogement: string
     case PROPRIETAIRE = 'PROPRIETAIRE';
     case LOCATAIRE = 'LOCATAIRE';
     case BAILLEUR = 'BAILLEUR';
+    case BAILLEUR_SOCIAL = 'BAILLEUR_SOCIAL';
     case AUTRE = 'AUTRE';
 
     public function getLibelle(): string
@@ -15,6 +16,7 @@ enum RapportAuLogement: string
             RapportAuLogement::PROPRIETAIRE => 'Propriétaire occupant',
             RapportAuLogement::LOCATAIRE => 'Locataire',
             RapportAuLogement::BAILLEUR => 'Propriétaire bailleur',
+            RapportAuLogement::BAILLEUR_SOCIAL => 'Bailleur social',
             RapportAuLogement::AUTRE => 'Autre',
         };
     }

--- a/frontend/src/apps/requerant/dossier/components/TestEligibiliteBrisPorteForm.tsx
+++ b/frontend/src/apps/requerant/dossier/components/TestEligibiliteBrisPorteForm.tsx
@@ -25,7 +25,11 @@ const AvancementTest: LibelleAvancementTest[] = [
   "a_contacte_bailleur",
 ];
 
-type RapportAuLogementType = "proprietaire" | "locataire" | "bailleur";
+type RapportAuLogementType =
+  | "proprietaire"
+  | "locataire"
+  | "bailleur"
+  | "bailleur_social";
 
 type TestEligibiliteBrisPorte = {
   avancement: LibelleAvancementTest;
@@ -226,6 +230,15 @@ export const TestEligibiliteBrisPorteForm = ({
                   checked: test.rapportAuLogement === "bailleur",
                   value: "BAILLEUR",
                   onChange: () => setRapportAuLogement("bailleur"),
+                },
+              },
+              {
+                label: "Bailleur social",
+                nativeInputProps: {
+                  name: "rapportAuLogement",
+                  checked: test.rapportAuLogement === "bailleur_social",
+                  value: "BAILLEUR_SOCIAL",
+                  onChange: () => setRapportAuLogement("bailleur_social"),
                 },
               },
             ]}

--- a/frontend/src/apps/requerant/dossier/creation_de_compte.tsx
+++ b/frontend/src/apps/requerant/dossier/creation_de_compte.tsx
@@ -1,7 +1,4 @@
-import {
-  Civilite,
-  Inscription,
-} from "@/apps/requerant/dossier/models/Inscription";
+import { Civilite, Inscription } from "@/apps/requerant/dossier/models/Inscription";
 import FranceConnectButton from "@codegouvfr/react-dsfr/FranceConnectButton";
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validate, ValidationError } from "class-validator";
@@ -27,6 +24,7 @@ interface Routes {
 const token: string = args.token;
 const routes: Routes = args.routes as Routes;
 const inscription = plainToInstance(Inscription, args.inscription);
+const proposerFranceConnect = !!(args.franceConnect || false);
 let erreurs = observable.map<string, string>([]);
 
 autorun(async (i) => {
@@ -56,7 +54,9 @@ const CreationDeCompteApp = observer(function CreationDeCompteApp({
   const [confirmationRevelee, setConfirmationRevelee] = useState(false);
   //const { pending: sauvegardeEnCours } = useFormStatus();
   const [sauvegardeEnCours, setSauvegardeEnCours] = useState(false);
-  const [inscriptionParEmail, setInscriptionParEmail] = useState(false);
+  const [inscriptionParEmail, setInscriptionParEmail] = useState(
+    !proposerFranceConnect,
+  );
 
   const creerLeCompte = async function () {
     setSauvegardeEnCours(true);
@@ -136,37 +136,41 @@ const CreationDeCompteApp = observer(function CreationDeCompteApp({
                       </p>
                     </div>
 
-                    <div className="fr-grid-row fr-grid-row--center">
-                      <div className="fr-notice fr-notice--info fr-mb-2w">
-                        <div className="fr-container">
-                          <div className="fr-notice__body">
-                            <p>
-                              FranceConnect est la solution proposée par l’État
-                              pour sécuriser et simplifier la connexion à vos
-                              services en ligne
-                            </p>
+                    {proposerFranceConnect && (
+                      <>
+                        <div className="fr-grid-row fr-grid-row--center">
+                          <div className="fr-notice fr-notice--info fr-mb-2w">
+                            <div className="fr-container">
+                              <div className="fr-notice__body">
+                                <p>
+                                  FranceConnect est la solution proposée par
+                                  l’État pour sécuriser et simplifier la
+                                  connexion à vos services en ligne
+                                </p>
+                              </div>
+                            </div>
                           </div>
+
+                          <FranceConnectButton
+                            url={routes.inscriptionFranceConnect}
+                          />
                         </div>
-                      </div>
 
-                      <FranceConnectButton
-                        url={routes.inscriptionFranceConnect}
-                      />
-                    </div>
+                        <div className="fr-section-separateur--ligne">
+                          <span>ou</span>
+                        </div>
 
-                    <div className="fr-section-separateur--ligne">
-                      <span>ou</span>
-                    </div>
-
-                    {!inscriptionParEmail && (
-                      <div className="fr-grid-row fr-grid-row--center">
-                        <button
-                          className="fr-btn"
-                          onClick={() => setInscriptionParEmail(true)}
-                        >
-                          S'inscrire avec une adresse email
-                        </button>
-                      </div>
+                        {!inscriptionParEmail && (
+                          <div className="fr-grid-row fr-grid-row--center">
+                            <button
+                              className="fr-btn"
+                              onClick={() => setInscriptionParEmail(true)}
+                            >
+                              S'inscrire avec une adresse email
+                            </button>
+                          </div>
+                        )}
+                      </>
                     )}
 
                     {inscriptionParEmail && (

--- a/frontend/src/apps/requerant/models/RapportAuLogement.ts
+++ b/frontend/src/apps/requerant/models/RapportAuLogement.ts
@@ -2,6 +2,7 @@ const RapportAuLogements = [
   "PROPRIETAIRE",
   "LOCATAIRE",
   "BAILLEUR",
+  "BAILLEUR_SOCIAL",
   "AUTRE",
 ] as const;
 type RapportAuLogement = (typeof RapportAuLogements)[number];
@@ -10,6 +11,7 @@ const RapportAuLogementLibelles: { [key in RapportAuLogement]: string } = {
   PROPRIETAIRE: "Propriétaire occupant",
   BAILLEUR: "Propriétaire bailleur",
   LOCATAIRE: "Locataire",
+  BAILLEUR_SOCIAL: "Bailleur social",
   AUTRE: "Autre",
 };
 

--- a/frontend/src/apps/requerant/routes/requerant/dossier/bris-de-porte/$id/1-bris-porte.tsx
+++ b/frontend/src/apps/requerant/routes/requerant/dossier/bris-de-porte/$id/1-bris-porte.tsx
@@ -6,7 +6,7 @@ import { TitreSection } from "@/apps/requerant/composants/TitreSection.tsx";
 import { container } from "@/apps/requerant/container.ts";
 import {
   extraireDonneesBrisDeporte,
-  SchemaValidationBrisPorte,
+  SchemaValidationBrisPorte
 } from "@/apps/requerant/formulaires/brisDePorte/1-bris-porte.schema";
 import {
   Adresse,
@@ -15,7 +15,7 @@ import {
   getRapportAuLogementLibelle,
   RapportAuLogement,
   TypePersonneMoraleType,
-  TypesPersonneMorale,
+  TypesPersonneMorale
 } from "@/apps/requerant/models";
 import { RapportAuLogements } from "@/apps/requerant/models/RapportAuLogement.ts";
 import { RouteurRequerant } from "@/apps/requerant/routeur";
@@ -30,13 +30,7 @@ import Notice from "@codegouvfr/react-dsfr/Notice";
 import { RadioButtons } from "@codegouvfr/react-dsfr/RadioButtons";
 import { Stepper } from "@codegouvfr/react-dsfr/Stepper";
 import { useForm } from "@tanstack/react-form";
-import {
-  createFileRoute,
-  notFound,
-  redirect,
-  useBlocker,
-  useNavigate,
-} from "@tanstack/react-router";
+import { createFileRoute, notFound, redirect, useBlocker, useNavigate } from "@tanstack/react-router";
 import { useInjection } from "inversify-react";
 import React, { useState } from "react";
 
@@ -320,7 +314,8 @@ function Etape1BrisPorte() {
             })}
             children={({ estPersonneMorale, typePersonneMorale }) => (
               <>
-                {(estPersonneMorale === false || !!typePersonneMorale) && (
+                {(estPersonneMorale === false ||
+                  typePersonneMorale != "BAILLEUR_SOCIAL") && (
                   <div className="fr-grid-row fr-grid-row--gutters">
                     <div className="fr-col-lg-6 fr-col-12">
                       <formulaire.Field


### PR DESCRIPTION
# Ajouter l'option bailleur social au test d'éligibilité

Et adapter le parcours ensuite pour :
* ne pas proposer FranceConnect à l'inscription dans ce cas précis (préférer l'adresse email professionnelle)
* automatiquement créer un dossier personne morale de type `BAILLEUR_SOCIAL`
* masquer le champs "Rapport au logement"