### PR TITLE
Permettre au rédacteur de transmettre à fip3 ses dossiers

### DIFF
--- a/backend/src/Api/Agent/Fip6/Endpoint/Dossier/DecompterDossierEndpoint.php
+++ b/backend/src/Api/Agent/Fip6/Endpoint/Dossier/DecompterDossierEndpoint.php
@@ -50,9 +50,15 @@ class DecompterDossierEndpoint
             $decomptes['arrete-a-signer'] = $dossierRepository->compterDossierParEtat(EtatDossierType::DOSSIER_OK_VERIFIE);
         }
 
-        if ($agent->aRole(Agent::ROLE_AGENT_LIAISON_BUDGET)) {
-            $decomptes['a-transmettre'] = $dossierRepository->compterDossierParEtat(EtatDossierType::DOSSIER_OK_A_INDEMNISER);
-            $decomptes['en-attente-indemnisation'] = $dossierRepository->compterDossierParEtat(EtatDossierType::DOSSIER_OK_EN_ATTENTE_PAIEMENT);
+        if ($agent->aRole(Agent::ROLE_AGENT_LIAISON_BUDGET) || $agent->estRedacteur()) {
+            if ($agent->aRole(Agent::ROLE_AGENT_LIAISON_BUDGET)) {
+
+                $decomptes['a-transmettre'] = $dossierRepository->compterDossierParEtat(EtatDossierType::DOSSIER_OK_A_INDEMNISER);
+                $decomptes['en-attente-indemnisation'] = $dossierRepository->compterDossierParEtat(EtatDossierType::DOSSIER_OK_EN_ATTENTE_PAIEMENT);
+            } else {
+                $decomptes['a-transmettre'] = $agent->nbDossiersATransmettreAFIP3();
+                $decomptes['en-attente-indemnisation'] = $agent->nbDossiersEnAttentePaiement();
+            }
         }
 
         return new JsonResponse($decomptes);

--- a/backend/src/Api/Agent/Fip6/Endpoint/Dossier/ListerDossierATransmettreEndpoint.php
+++ b/backend/src/Api/Agent/Fip6/Endpoint/Dossier/ListerDossierATransmettreEndpoint.php
@@ -2,11 +2,13 @@
 
 namespace MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Dossier;
 
-use Doctrine\ORM\EntityManagerInterface;
 use MonIndemnisationJustice\Api\Agent\Fip6\Output\DossierATransmettreOutput;
 use MonIndemnisationJustice\Api\Agent\Fip6\Voter\DossierVoter;
+use MonIndemnisationJustice\Entity\Agent;
 use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\EtatDossierType;
+use MonIndemnisationJustice\Repository\DossierRepository;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -21,23 +23,21 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 class ListerDossierATransmettreEndpoint
 {
     public function __construct(
-        protected readonly EntityManagerInterface $entityManager,
+        protected readonly DossierRepository $dossierRepository,
         protected readonly NormalizerInterface $normalizer,
     ) {
     }
 
-    public function __invoke(): Response
-    {
-        $dossiers = $this->entityManager->getRepository(Dossier::class)->listerDossierParEtat(EtatDossierType::DOSSIER_OK_A_INDEMNISER);
+    public function __invoke(
+        Security $security,
+    ): Response {
+        /** @var Agent $agent */
+        $agent = $security->getUser();
+        $dossiers = $agent->estRedacteur() ? $agent->getDossiersATransmettreAFIP3() : $this->dossierRepository->listerDossierParEtat(EtatDossierType::DOSSIER_OK_A_INDEMNISER);
 
         return new JsonResponse(
             $this->normalizer->normalize(
                 array_map(
-                    /* Pas réussi à utiliser l'ObjectMapper ici : il se plaitn de ne pas trouver les champs
-                    `dateValidation` et `agentValidateur` dans la classe source, ce qui est tout de même ballot pour un
-                    mapper ... Et je n'ai pas non plus réussi à utiliser des _arrow function_ en guise de callable
-                    transformer, pas plus que de déléguer à un transformer de classe (jamais appelé ...).
-                    */
                     fn (Dossier $dossier) => DossierATransmettreOutput::creerDepuisDossier($dossier),
                     $dossiers
                 ),

--- a/backend/src/Api/Agent/Fip6/Endpoint/Dossier/ListerDossierEnAttenteIndemnisationEndpoint.php
+++ b/backend/src/Api/Agent/Fip6/Endpoint/Dossier/ListerDossierEnAttenteIndemnisationEndpoint.php
@@ -2,11 +2,13 @@
 
 namespace MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Dossier;
 
-use Doctrine\ORM\EntityManagerInterface;
 use MonIndemnisationJustice\Api\Agent\Fip6\Output\DossierEnAttenteIndemnisationOutput;
 use MonIndemnisationJustice\Api\Agent\Fip6\Voter\DossierVoter;
+use MonIndemnisationJustice\Entity\Agent;
 use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\EtatDossierType;
+use MonIndemnisationJustice\Repository\DossierRepository;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -21,23 +23,21 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 class ListerDossierEnAttenteIndemnisationEndpoint
 {
     public function __construct(
-        protected readonly EntityManagerInterface $entityManager,
+        protected readonly DossierRepository $dossierRepository,
         protected readonly NormalizerInterface $normalizer,
     ) {
     }
 
-    public function __invoke(): Response
-    {
-        $dossiers = $this->entityManager->getRepository(Dossier::class)->listerDossierParEtat(EtatDossierType::DOSSIER_OK_EN_ATTENTE_PAIEMENT);
+    public function __invoke(
+        Security $security,
+    ): Response {
+        /** @var Agent $agent */
+        $agent = $security->getUser();
+        $dossiers = $agent->estRedacteur() ? $agent->getDossiersEnAttentePaiement() : $this->dossierRepository->listerDossierParEtat(EtatDossierType::DOSSIER_OK_EN_ATTENTE_PAIEMENT);
 
         return new JsonResponse(
             $this->normalizer->normalize(
                 array_map(
-                    /* Pas réussi à utiliser l'ObjectMapper ici : il se plaitn de ne pas trouver les champs
-                    `dateValidation` et `agentValidateur` dans la classe source, ce qui est tout de même ballot pour un
-                    mapper ... Et je n'ai pas non plus réussi à utiliser des _arrow function_ en guise de callable
-                    transformer, pas plus que de déléguer à un transformer de classe (jamais appelé ...).
-                    */
                     fn (Dossier $dossier) => DossierEnAttenteIndemnisationOutput::creerDepuisDossier($dossier),
                     $dossiers
                 ),

--- a/backend/src/Api/Agent/Fip6/Endpoint/Dossier/MarquerDossierIndemniseEndpoint.php
+++ b/backend/src/Api/Agent/Fip6/Endpoint/Dossier/MarquerDossierIndemniseEndpoint.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Dossier;
+
+use MonIndemnisationJustice\Api\Agent\Fip6\Output\DossierDetailOutput;
+use MonIndemnisationJustice\Api\Agent\Fip6\Voter\DossierVoter;
+use MonIndemnisationJustice\Entity\Dossier;
+use MonIndemnisationJustice\Entity\EtatDossierType;
+use MonIndemnisationJustice\Repository\DossierRepository;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+#[Route('/api/agent/fip6/dossier/{id}/marquer-indemnise', name: 'api_agent_fip6_dossier_marquer_indemnise', methods: ['POST'])]
+#[IsGranted(DossierVoter::ACTION_TRANSMETTRE_A_FIP3, subject: 'dossier', message: 'Seul le rédacteur ou un agent habilité peut transmettre les éléments à FIP3', statusCode: Response::HTTP_FORBIDDEN)]
+class MarquerDossierIndemniseEndpoint
+{
+    public function __construct(
+        protected readonly DossierRepository $dossierRepository,
+    ) {
+    }
+
+    public function __invoke(
+        #[MapEntity]
+        Dossier $dossier,
+        NormalizerInterface $normalizer,
+        Security $security,
+    ) {
+        $dossier->changerStatut(EtatDossierType::DOSSIER_OK_INDEMNISE, agent: $security->getUser());
+        $this->dossierRepository->save($dossier);
+
+        return new JsonResponse(
+            $normalizer->normalize(DossierDetailOutput::creerDepuisDossier($dossier), 'json'),
+            Response::HTTP_OK
+        );
+    }
+}

--- a/backend/src/Api/Agent/Fip6/Endpoint/Dossier/MarquerDossierIndemniseEndpoint.php
+++ b/backend/src/Api/Agent/Fip6/Endpoint/Dossier/MarquerDossierIndemniseEndpoint.php
@@ -10,6 +10,7 @@ use MonIndemnisationJustice\Repository\DossierRepository;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -29,8 +30,15 @@ class MarquerDossierIndemniseEndpoint
         Dossier $dossier,
         NormalizerInterface $normalizer,
         Security $security,
+        Request $request,
     ) {
-        $dossier->changerStatut(EtatDossierType::DOSSIER_OK_INDEMNISE, agent: $security->getUser());
+        /** @var \DateTime $dateIndemnisation */
+        $dateIndemnisation = max(min(\DateTime::createFromFormat('Y-m-d', $request->request->get('dateIndemnisation')), new \DateTime()), \DateTime::createFromImmutable($dossier->getEtatDossier()->getDateEntree()))->setTime(0, 0);
+
+        $dossier
+            ->changerStatut(EtatDossierType::DOSSIER_OK_INDEMNISE, agent: $security->getUser())->getEtatDossier()
+            ->setDateEntree(\DateTimeImmutable::createFromMutable($dateIndemnisation));
+
         $this->dossierRepository->save($dossier);
 
         return new JsonResponse(

--- a/backend/src/Api/Agent/Fip6/Endpoint/Dossier/TransmettreAFIP3Endpoint.php
+++ b/backend/src/Api/Agent/Fip6/Endpoint/Dossier/TransmettreAFIP3Endpoint.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Dossier;
+
+use MonIndemnisationJustice\Api\Agent\Fip6\Output\DossierDetailOutput;
+use MonIndemnisationJustice\Api\Agent\Fip6\Voter\DossierVoter;
+use MonIndemnisationJustice\Entity\Dossier;
+use MonIndemnisationJustice\Entity\EtatDossierType;
+use MonIndemnisationJustice\Repository\DossierRepository;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+#[Route('/api/agent/fip6/dossier/{id}/transmettre-a-fip3', name: 'api_agent_fip6_dossier_transmettre_a_fip3', methods: ['POST'])]
+#[IsGranted(DossierVoter::ACTION_TRANSMETTRE_A_FIP3, subject: 'dossier', message: 'Seul le rédacteur ou un agent habilité peut transmettre les éléments à FIP3', statusCode: Response::HTTP_FORBIDDEN)]
+class TransmettreAFIP3Endpoint
+{
+    public function __construct(
+        protected readonly DossierRepository $dossierRepository,
+    ) {
+    }
+
+    public function __invoke(
+        #[MapEntity]
+        Dossier $dossier,
+        NormalizerInterface $normalizer,
+        Security $security,
+    ) {
+        $dossier->changerStatut(EtatDossierType::DOSSIER_OK_EN_ATTENTE_PAIEMENT, agent: $security->getUser());
+        $this->dossierRepository->save($dossier);
+
+        return new JsonResponse(
+            $normalizer->normalize(DossierDetailOutput::creerDepuisDossier($dossier), 'json'),
+            Response::HTTP_OK
+        );
+    }
+}

--- a/backend/src/Api/Agent/Fip6/Voter/DossierVoter.php
+++ b/backend/src/Api/Agent/Fip6/Voter/DossierVoter.php
@@ -19,6 +19,8 @@ class DossierVoter extends Voter
     public const string ACTION_AJOUTER_PIECE_JOINTE = 'dossier:ajouter-piece-jointe';
     public const string ACTION_GENERER_DOCUMENT = 'dossier:generer-document';
 
+    public const string ACTION_TRANSMETTRE_A_FIP3 = 'dossier:transmettre:a_fip3';
+
     public const string ACTION_LISTER_A_CATEGORISER = 'dossier:lister:a-categoriser';
     public const string ACTION_LISTER_A_ATTRIBUER = 'dossier:lister:a-attribuer';
     public const string ACTION_LISTER_A_INSTRUIRE = 'dossier:lister:a-instruire';
@@ -41,6 +43,7 @@ class DossierVoter extends Voter
             self::ACTION_CLOTURER,
             self::ACTION_AJOUTER_PIECE_JOINTE,
             self::ACTION_GENERER_DOCUMENT,
+            self::ACTION_TRANSMETTRE_A_FIP3,
             self::ACTION_LISTER_A_CATEGORISER,
             self::ACTION_LISTER_A_ATTRIBUER,
             self::ACTION_LISTER_A_INSTRUIRE,
@@ -77,6 +80,7 @@ class DossierVoter extends Voter
             self::ACTION_INSTRUIRE => $this->agentPeutInstruire($agent, $subject),
             self::ACTION_CLOTURER => $this->agentPeutCloturer($agent, $subject),
             self::ACTION_GENERER_DOCUMENT, => $this->agentPeutGenererDocument($agent, $subject),
+            self::ACTION_TRANSMETTRE_A_FIP3, => $this->agentPeutTransmettreAFIP3($agent, $subject),
             self::ACTION_LISTER_A_CATEGORISER, self::ACTION_LISTER_A_ATTRIBUER, self::ACTION_LISTER_A_INSTRUIRE, self::ACTION_LISTER_EN_INSTRUCTION, self::ACTION_LISTER_REJET_A_SIGNER, self::ACTION_LISTER_PROPOSITION_A_SIGNER, self::ACTION_LISTER_A_VERIFIER, self::ACTION_LISTER_ARRETE_A_SIGNER, self::ACTION_LISTER_A_TRANSMETTRE, self::ACTION_LISTER_EN_ATTENTE_INDEMNISATION => $this->agentPeutLister($agent, $attribute),
             default => false,
         };
@@ -115,6 +119,11 @@ class DossierVoter extends Voter
     protected function agentPeutGenererDocument(Agent $agent, Dossier $dossier): bool
     {
         return ($agent->estRedacteur() && $agent->instruit($dossier)) || $agent->aRole(Agent::ROLE_AGENT_VALIDATEUR);
+    }
+
+    protected function agentPeutTransmettreAFIP3(Agent $agent, Dossier $dossier): bool
+    {
+        return $agent->aRole(Agent::ROLE_AGENT_LIAISON_BUDGET) || $agent->instruit($dossier);
     }
 
     protected function agentPeutLister(Agent $agent, string $action): bool

--- a/backend/src/Api/Agent/Fip6/Voter/DossierVoter.php
+++ b/backend/src/Api/Agent/Fip6/Voter/DossierVoter.php
@@ -133,7 +133,7 @@ class DossierVoter extends Voter
             self::ACTION_LISTER_A_ATTRIBUER => $agent->aRole(Agent::ROLE_AGENT_ATTRIBUTEUR),
             self::ACTION_LISTER_A_INSTRUIRE, self::ACTION_LISTER_EN_INSTRUCTION, self::ACTION_LISTER_A_VERIFIER => $agent->aRole(Agent::ROLE_AGENT_REDACTEUR),
             self::ACTION_LISTER_REJET_A_SIGNER, self::ACTION_LISTER_PROPOSITION_A_SIGNER, self::ACTION_LISTER_ARRETE_A_SIGNER => $agent->aRole(Agent::ROLE_AGENT_VALIDATEUR),
-            self::ACTION_LISTER_A_TRANSMETTRE, self::ACTION_LISTER_EN_ATTENTE_INDEMNISATION => $agent->aRole(Agent::ROLE_AGENT_LIAISON_BUDGET),
+            self::ACTION_LISTER_A_TRANSMETTRE, self::ACTION_LISTER_EN_ATTENTE_INDEMNISATION => $agent->aRole(Agent::ROLE_AGENT_LIAISON_BUDGET) || $agent->estRedacteur(),
             default => false,
         };
     }

--- a/backend/src/Api/Requerant/Dossier/Dto/DossierDto.php
+++ b/backend/src/Api/Requerant/Dossier/Dto/DossierDto.php
@@ -77,7 +77,7 @@ class DossierDto
             idDeclarationFDO: $dossier->getBrisPorte()->getDeclarationFDO()?->getId(),
             estPorteBlindee: $dossier->getBrisPorte()?->estPorteBlindee(),
             description: $dossier->getBrisPorte()->getDescriptionRequerant(),
-            piecesJointes: $dossier->getPiecesJointes()->map(fn (Document $pieceJointe) => PieceJointeDto::depuisDocument($pieceJointe))->toArray(),
+            piecesJointes: $dossier->getPiecesJointes()->map(fn (Document $pieceJointe) => PieceJointeDto::depuisDocument($pieceJointe))->getValues(),
         );
     }
 }

--- a/backend/src/Controller/Agent/DocumentController.php
+++ b/backend/src/Controller/Agent/DocumentController.php
@@ -4,16 +4,20 @@ namespace MonIndemnisationJustice\Controller\Agent;
 
 use League\Flysystem\FilesystemException;
 use League\Flysystem\UnableToReadFile;
+use MonIndemnisationJustice\Api\Agent\Fip6\Voter\DossierVoter;
 use MonIndemnisationJustice\Entity\Agent;
 use MonIndemnisationJustice\Entity\Document;
+use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Service\DocumentManager;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
@@ -79,5 +83,36 @@ class DocumentController extends AbstractController
         $this->documentManager->supprimer($document);
 
         return JsonResponse::fromJsonString('', Response::HTTP_NO_CONTENT);
+    }
+
+    #[IsGranted(DossierVoter::ACTION_TRANSMETTRE_A_FIP3, subject: 'dossier', message: 'Seul un agent habilité peut transmettre le dossier', statusCode: Response::HTTP_FORBIDDEN)]
+    #[Route('/{id}/documents-a-transmettre', name: 'agent_document_telecharger_a_transmettre_a_fip3', methods: ['GET'])]
+    public function documentsATransmettreAFIP3(#[MapEntity] Dossier $dossier, Request $request): Response
+    {
+        $zip = new \ZipArchive();
+        $zipName = tempnam(sys_get_temp_dir(), "zip_dossier_{$dossier->getId()}");
+
+        if (true !== $zip->open($zipName, \ZipArchive::CREATE)) {
+            throw new \RuntimeException('Cannot open '.$zipName);
+        }
+
+        /** @var Document $document */
+        foreach ($dossier->getDocumentsATransmettre()->toArray() as $document) {
+            try {
+                $contenu = $this->documentManager->getContenuTexte($document);
+                $zip->addFromString(preg_replace('#/#', '', $document->getOriginalFilename()), $contenu);
+            } catch (FilesystemException|UnableToReadFile $e) {
+                $this->logger->warning('Fichier de pièce jointe introuvable', ['id' => $document->getId(), 'erreur' => $e->getMessage()]);
+                // $this->documentManager->supprimer($document);
+            }
+        }
+
+        $zip->close();
+
+        return new BinaryFileResponse($zipName, headers: [
+            'Content-Type' => 'application/zip',
+            'Content-Length' => filesize($zipName),
+        ])
+            ->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, preg_replace('/\//', '', "Dossier {$dossier->getReference()}.zip"));
     }
 }

--- a/backend/src/Controller/Agent/DocumentController.php
+++ b/backend/src/Controller/Agent/DocumentController.php
@@ -97,7 +97,7 @@ class DocumentController extends AbstractController
         }
 
         /** @var Document $document */
-        foreach ($dossier->getDocumentsATransmettre()->toArray() as $document) {
+        foreach ($dossier->getDocumentsATransmettre()->getValues() as $document) {
             try {
                 $contenu = $this->documentManager->getContenuTexte($document);
                 $zip->addFromString(preg_replace('#/#', '', $document->getOriginalFilename()), $contenu);

--- a/backend/src/Controller/Agent/DocumentController.php
+++ b/backend/src/Controller/Agent/DocumentController.php
@@ -86,7 +86,7 @@ class DocumentController extends AbstractController
     }
 
     #[IsGranted(DossierVoter::ACTION_TRANSMETTRE_A_FIP3, subject: 'dossier', message: 'Seul un agent habilité peut transmettre le dossier', statusCode: Response::HTTP_FORBIDDEN)]
-    #[Route('/{id}/documents-a-transmettre', name: 'agent_document_telecharger_a_transmettre_a_fip3', methods: ['GET'])]
+    #[Route('/dossier/{id}/documents-a-transmettre', name: 'agent_document_telecharger_a_transmettre_a_fip3', methods: ['GET'])]
     public function documentsATransmettreAFIP3(#[MapEntity] Dossier $dossier, Request $request): Response
     {
         $zip = new \ZipArchive();

--- a/backend/src/Controller/Agent/DossierController.php
+++ b/backend/src/Controller/Agent/DossierController.php
@@ -3,12 +3,9 @@
 namespace MonIndemnisationJustice\Controller\Agent;
 
 use Doctrine\ORM\EntityManagerInterface;
-use League\Flysystem\FilesystemException;
-use League\Flysystem\UnableToReadFile;
 use MonIndemnisationJustice\Api\Agent\Fip6\Output\EtatDossierOutput;
 use MonIndemnisationJustice\Api\Agent\Fip6\Output\PieceJointeOutput;
 use MonIndemnisationJustice\Entity\Agent;
-use MonIndemnisationJustice\Entity\Document;
 use MonIndemnisationJustice\Entity\DocumentType;
 use MonIndemnisationJustice\Entity\Dossier;
 use MonIndemnisationJustice\Entity\EtatDossierType;
@@ -20,13 +17,11 @@ use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\ExpressionLanguage\Expression;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -221,43 +216,6 @@ class DossierController extends AgentController
         $this->dossierRepository->save($dossier);
 
         return new JsonResponse('', Response::HTTP_NO_CONTENT);
-    }
-
-    // TODO déplacer dans une route API dédiée
-    #[IsGranted(
-        attribute: new Expression('is_granted("ROLE_AGENT_LIAISON_BUDGET") and subject["dossier"].getEtatDossier().estAEnvoyerPourIndemnisation()'),
-        subject: [
-            'dossier' => new Expression('args["dossier"]'),
-        ]
-    )]
-    #[Route('/{id}/documents-a-transmettre', name: 'agent_redacteur_documents_a_transmettre_dossier', methods: ['GET'])]
-    public function download(#[MapEntity] Dossier $dossier, Request $request): Response
-    {
-        $zip = new \ZipArchive();
-        $zipName = tempnam(sys_get_temp_dir(), "zip_dossier_{$dossier->getId()}");
-
-        if (true !== $zip->open($zipName, \ZipArchive::CREATE)) {
-            throw new \RuntimeException('Cannot open '.$zipName);
-        }
-
-        /** @var Document $document */
-        foreach ($dossier->getDocumentsATransmettre()->toArray() as $document) {
-            try {
-                $contenu = $this->documentManager->getContenuTexte($document);
-                $zip->addFromString(preg_replace('#/#', '', $document->getOriginalFilename()), $contenu);
-            } catch (FilesystemException|UnableToReadFile $e) {
-                $this->logger->warning('Fichier de pièce jointe introuvable', ['id' => $document->getId(), 'erreur' => $e->getMessage()]);
-                // $this->documentManager->supprimer($document);
-            }
-        }
-
-        $zip->close();
-
-        return new BinaryFileResponse($zipName, headers: [
-            'Content-Type' => 'application/zip',
-            'Content-Length' => filesize($zipName),
-        ])
-            ->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, preg_replace('/\//', '', "Dossier {$dossier->getReference()}.zip"));
     }
 
     // TODO déplacer dans une route API dédiée

--- a/backend/src/Controller/Agent/DossierController.php
+++ b/backend/src/Controller/Agent/DossierController.php
@@ -5,7 +5,6 @@ namespace MonIndemnisationJustice\Controller\Agent;
 use Doctrine\ORM\EntityManagerInterface;
 use MonIndemnisationJustice\Api\Agent\Fip6\Output\EtatDossierOutput;
 use MonIndemnisationJustice\Api\Agent\Fip6\Output\PieceJointeOutput;
-use MonIndemnisationJustice\Api\Agent\Fip6\Voter\DossierVoter;
 use MonIndemnisationJustice\Entity\Agent;
 use MonIndemnisationJustice\Entity\DocumentType;
 use MonIndemnisationJustice\Entity\Dossier;
@@ -217,31 +216,5 @@ class DossierController extends AgentController
         $this->dossierRepository->save($dossier);
 
         return new JsonResponse('', Response::HTTP_NO_CONTENT);
-    }
-
-    // TODO déplacer dans une route API dédiée
-    #[IsGranted(DossierVoter::ACTION_TRANSMETTRE_A_FIP3, subject: 'dossier', message: 'Seul le rédacteur ou un agent habilité peut transmettre les éléments à FIP3', statusCode: Response::HTTP_FORBIDDEN)]
-    #[Route('/dossier/{id}/envoyer-pour-indemnisation.json', name: 'agent_redacteur_envoyer_pour_indemnisation_dossier', methods: ['POST'])]
-    public function envoyerPourIndemnisationDossier(#[MapEntity] Dossier $dossier): Response
-    {
-        $dossier->changerStatut(EtatDossierType::DOSSIER_OK_EN_ATTENTE_PAIEMENT, agent: $this->getAgent());
-        $this->dossierRepository->save($dossier);
-
-        return new JsonResponse([
-            'etat' => $this->normalizer->normalize(EtatDossierOutput::depuisEtatDossier($dossier->getEtatDossier()), 'json'),
-        ], Response::HTTP_OK);
-    }
-
-    // TODO déplacer dans une route API dédiée
-    #[IsGranted(DossierVoter::ACTION_TRANSMETTRE_A_FIP3, subject: 'dossier', message: 'Seul le rédacteur ou un agent habilité peut marquer le dossier comme indemnisé', statusCode: Response::HTTP_FORBIDDEN)]
-    #[Route('/dossier/{id}/marquer-indemnise.json', name: 'agent_redacteur_marquer_indemnise_dossier', methods: ['POST'])]
-    public function marquerIndemniseDossier(#[MapEntity] Dossier $dossier): Response
-    {
-        $dossier->changerStatut(EtatDossierType::DOSSIER_OK_INDEMNISE, agent: $this->getAgent());
-        $this->dossierRepository->save($dossier);
-
-        return new JsonResponse([
-            'etat' => $this->normalizer->normalize(EtatDossierOutput::depuisEtatDossier($dossier->getEtatDossier()), 'json'),
-        ], Response::HTTP_OK);
     }
 }

--- a/backend/src/Controller/Agent/DossierController.php
+++ b/backend/src/Controller/Agent/DossierController.php
@@ -5,6 +5,7 @@ namespace MonIndemnisationJustice\Controller\Agent;
 use Doctrine\ORM\EntityManagerInterface;
 use MonIndemnisationJustice\Api\Agent\Fip6\Output\EtatDossierOutput;
 use MonIndemnisationJustice\Api\Agent\Fip6\Output\PieceJointeOutput;
+use MonIndemnisationJustice\Api\Agent\Fip6\Voter\DossierVoter;
 use MonIndemnisationJustice\Entity\Agent;
 use MonIndemnisationJustice\Entity\DocumentType;
 use MonIndemnisationJustice\Entity\Dossier;
@@ -219,12 +220,7 @@ class DossierController extends AgentController
     }
 
     // TODO déplacer dans une route API dédiée
-    #[IsGranted(
-        attribute: new Expression('is_granted("ROLE_AGENT_LIAISON_BUDGET") and subject["dossier"].getEtatDossier().estAEnvoyerPourIndemnisation()'),
-        subject: [
-            'dossier' => new Expression('args["dossier"]'),
-        ]
-    )]
+    #[IsGranted(DossierVoter::ACTION_TRANSMETTRE_A_FIP3, subject: 'dossier', message: 'Seul le rédacteur ou un agent habilité peut transmettre les éléments à FIP3', statusCode: Response::HTTP_FORBIDDEN)]
     #[Route('/dossier/{id}/envoyer-pour-indemnisation.json', name: 'agent_redacteur_envoyer_pour_indemnisation_dossier', methods: ['POST'])]
     public function envoyerPourIndemnisationDossier(#[MapEntity] Dossier $dossier): Response
     {
@@ -237,12 +233,7 @@ class DossierController extends AgentController
     }
 
     // TODO déplacer dans une route API dédiée
-    #[IsGranted(
-        attribute: new Expression('is_granted("ROLE_AGENT_LIAISON_BUDGET") and subject["dossier"].getEtatDossier().estEnAttenteIndemnisation()'),
-        subject: [
-            'dossier' => new Expression('args["dossier"]'),
-        ]
-    )]
+    #[IsGranted(DossierVoter::ACTION_TRANSMETTRE_A_FIP3, subject: 'dossier', message: 'Seul le rédacteur ou un agent habilité peut marquer le dossier comme indemnisé', statusCode: Response::HTTP_FORBIDDEN)]
     #[Route('/dossier/{id}/marquer-indemnise.json', name: 'agent_redacteur_marquer_indemnise_dossier', methods: ['POST'])]
     public function marquerIndemniseDossier(#[MapEntity] Dossier $dossier): Response
     {

--- a/backend/src/Entity/Agent.php
+++ b/backend/src/Entity/Agent.php
@@ -263,7 +263,7 @@ class Agent implements UserInterface
      */
     protected function getDossiersParEtatActuel(EtatDossierType $etatActuel): array
     {
-        return $this->dossiers->filter(fn (Dossier $dossier) => $dossier->getEtatDossier()->getEtat() === $etatActuel)->toArray();
+        return $this->dossiers->filter(fn (Dossier $dossier) => $dossier->getEtatDossier()->getEtat() === $etatActuel)->getValues();
     }
 
     public function nbDossiersAInstruire(): int
@@ -303,6 +303,32 @@ class Agent implements UserInterface
     public function getDossiersAVerifier(): array
     {
         return $this->hasRole(Agent::ROLE_AGENT_REDACTEUR) ? $this->getDossiersParEtatActuel(EtatDossierType::DOSSIER_OK_A_VERIFIER) : [];
+    }
+
+    public function nbDossiersATransmettreAFIP3(): int
+    {
+        return count($this->getDossiersATransmettreAFIP3());
+    }
+
+    /**
+     * @return Dossier[]
+     */
+    public function getDossiersATransmettreAFIP3(): array
+    {
+        return $this->hasRole(Agent::ROLE_AGENT_REDACTEUR) ? $this->getDossiersParEtatActuel(EtatDossierType::DOSSIER_OK_A_INDEMNISER) : [];
+    }
+
+    /**
+     * @return Dossier[]
+     */
+    public function getDossiersEnAttentePaiement(): array
+    {
+        return $this->hasRole(Agent::ROLE_AGENT_REDACTEUR) ? $this->getDossiersParEtatActuel(EtatDossierType::DOSSIER_OK_EN_ATTENTE_PAIEMENT) : [];
+    }
+
+    public function nbDossiersEnAttentePaiement(): int
+    {
+        return count($this->getDossiersEnAttentePaiement());
     }
 
     /**

--- a/backend/src/Event/Listener/DossierTransitionListener.php
+++ b/backend/src/Event/Listener/DossierTransitionListener.php
@@ -152,16 +152,14 @@ class DossierTransitionListener
     public function dossierArreteSigne(DossierArreteSigneEvent $evenement): void
     {
         // Prévenir le rédacteur que son dossier est prêt à être transmis à FIP3:
-        foreach ($this->agentRepository->getAgentsLiaisonBudget() as $agentLiaisonBudget) {
-            $this->mailer
-                ->toAgent($evenement->dossier->getRedacteur())
-                ->subject('Mon Indemnisation Justice: votre dossier peut être transmis à FIP3 ')
-                ->htmlTemplate('email/agent/fip6/dossier_a_transmettre.twig', [
-                    'agent' => $evenement->dossier->getRedacteur(),
-                    'dossier' => $evenement->dossier,
-                ])
-                ->send();
-        }
+        $this->mailer
+            ->toAgent($evenement->dossier->getRedacteur())
+            ->subject('Mon Indemnisation Justice: votre dossier peut être transmis à FIP3 ')
+            ->htmlTemplate('email/agent/fip6/dossier_a_transmettre.twig', [
+                'agent' => $evenement->dossier->getRedacteur(),
+                'dossier' => $evenement->dossier,
+            ])
+            ->send();
     }
 
     public function dossierRejete(DossierRejeteEvent $evenement): void

--- a/backend/src/Event/Listener/DossierTransitionListener.php
+++ b/backend/src/Event/Listener/DossierTransitionListener.php
@@ -151,13 +151,13 @@ class DossierTransitionListener
 
     public function dossierArreteSigne(DossierArreteSigneEvent $evenement): void
     {
-        // Prévenir l'agent de liaison avec le bureau du budget qu'un dossier est prêt pour transmission :
+        // Prévenir le rédacteur que son dossier est prêt à être transmis à FIP3:
         foreach ($this->agentRepository->getAgentsLiaisonBudget() as $agentLiaisonBudget) {
             $this->mailer
-                ->toAgent($agentLiaisonBudget)
-                ->subject('Mon Indemnisation Justice: vous avez un nouveau dossier à transmettre à FIP3 ')
+                ->toAgent($evenement->dossier->getRedacteur())
+                ->subject('Mon Indemnisation Justice: votre dossier peut être transmis à FIP3 ')
                 ->htmlTemplate('email/agent/fip6/dossier_a_transmettre.twig', [
-                    'agent' => $agentLiaisonBudget,
+                    'agent' => $evenement->dossier->getRedacteur(),
                     'dossier' => $evenement->dossier,
                 ])
                 ->send();

--- a/backend/templates/email/agent/fip6/dossier_a_transmettre.twig
+++ b/backend/templates/email/agent/fip6/dossier_a_transmettre.twig
@@ -18,11 +18,11 @@
         dossier <b>{{ dossier.reference }}</b>, il peut désormais être transmis au bureau du budget.
     </p>
     <p>
-        Vous pouvez consulter le dossier et le transmettre en cliquant sur le bouton ci-dessous :
+        Vous pouvez voir la liste de tous {% if agent.estRedacteur %}vos{% else %}les{% endif%} dossiers à transmettre en cliquant sur le bouton ci-dessous :
     </p>
     <br/>
     <p>
-        {{ email.bouton("Dossier " ~ dossier.reference, url('agent_fip6_react', {'extra': "dossier/" ~ dossier.id})) }}
+        {{ email.bouton("Dossiers à transmettre au bureau du budget", url('agent_fip6_react', {'extra': "dossiers/a-transmettre"})) }}
         <br/>
     </p>
     <br/>

--- a/backend/templates/email/agent/fip6/dossier_a_transmettre.twig
+++ b/backend/templates/email/agent/fip6/dossier_a_transmettre.twig
@@ -18,11 +18,11 @@
         dossier <b>{{ dossier.reference }}</b>, il peut désormais être transmis au bureau du budget.
     </p>
     <p>
-        Vous pouvez voir la liste de tous les dossiers à transmettre en cliquant sur le bouton ci-dessous :
+        Vous pouvez consulter le dossier et le transmettre en cliquant sur le bouton ci-dessous :
     </p>
     <br/>
     <p>
-        {{ email.bouton("Dossiers à transmettre au bureau du budget", url('agent_fip6_react', {'extra': "dossiers/a-transmettre"})) }}
+        {{ email.bouton("Dossier " ~ dossier.reference, url('agent_fip6_react', {'extra': "dossier/" ~ dossier.id})) }}
         <br/>
     </p>
     <br/>

--- a/backend/tests/Api/Agent/Fip6/AbstractEndpointTestCase.php
+++ b/backend/tests/Api/Agent/Fip6/AbstractEndpointTestCase.php
@@ -44,10 +44,15 @@ abstract class AbstractEndpointTestCase extends WebTestCase
         $agent = $this->getAgent($courriel);
 
         if ($agent) {
-            $this->client->loginUser($agent, 'agent');
+            $this->connexionAgent($agent);
         }
 
         return $agent;
+    }
+
+    protected function connexionAgent(Agent $agent): void
+    {
+        $this->client->loginUser($agent, 'agent');
     }
 
     protected function assertArrayEquals(array $expected, mixed $actual): void

--- a/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/DecompterDossierEndpointTest.php
+++ b/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/DecompterDossierEndpointTest.php
@@ -24,6 +24,8 @@ class DecompterDossierEndpointTest extends AbstractEndpointTestCase
             'a-instruire' => $redacteur->nbDossiersAInstruire(),
             'en-instruction' => $redacteur->nbDossiersEnInstruction(),
             'a-verifier' => $redacteur->nbDossiersAVerifier(),
+            'a-transmettre' => $redacteur->nbDossiersATransmettreAFIP3(),
+            'en-attente-indemnisation' => $redacteur->nbDossiersEnAttentePaiement(),
         ], $donnees);
     }
 }

--- a/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/MarquerDossierIndemniseEndpointTest.php
+++ b/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/MarquerDossierIndemniseEndpointTest.php
@@ -3,46 +3,77 @@
 namespace Api\Agent\Fip6\Dossier\Endpoint;
 
 use MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Dossier\MarquerDossierIndemniseEndpoint;
+use MonIndemnisationJustice\Entity\EtatDossier;
 use MonIndemnisationJustice\Entity\EtatDossierType;
 use MonIndemnisationJustice\Tests\Api\Agent\Fip6\AbstractEndpointTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(MarquerDossierIndemniseEndpoint::class)]
 class MarquerDossierIndemniseEndpointTest extends AbstractEndpointTestCase
 {
+    public static function donnesMarquerDossierIndemnise()
+    {
+        return [
+            'meme_jour' => [fn (EtatDossier $etat) => $etat->getDateEntree(), fn (EtatDossier $etat) => $etat->getDateEntree()],
+            'date_1jour_trop_tot' => [fn (EtatDossier $etat) => $etat->getDateEntree()->sub(\DateInterval::createFromDateString('1 day')), fn (EtatDossier $etat) => $etat->getDateEntree()],
+            'date_demain' => [fn (EtatDossier $etat) => new \DateTime()->add(\DateInterval::createFromDateString('1 day')), fn (EtatDossier $etat) => new \DateTime()],
+        ];
+    }
+
     /**
      * ETQ rédacteur du dossier, je dois pouvoir marquer le dossier comme indemnisé.
      */
-    public function testMarquerDossierIndemniseRedacteurOk()
+    #[DataProvider('donnesMarquerDossierIndemnise')]
+    public function testMarquerDossierIndemniseRedacteurOk(callable $calculerDateIndemnisationEnvoyee, callable $calculerDateIndemnisationAttendue)
     {
+
         $dossier = $this->getDossierParEtat(EtatDossierType::DOSSIER_OK_EN_ATTENTE_PAIEMENT);
+        /** @var \DateTime $dateIndemnisationEnvoyee */
+        $dateIndemnisationEnvoyee = $calculerDateIndemnisationEnvoyee($dossier->getEtatDossier());
+        /** @var \DateTime $dateIndemnisationAttendue */
+        $dateIndemnisationAttendue = $calculerDateIndemnisationAttendue($dossier->getEtatDossier());
 
         $this->connexionAgent($dossier->getRedacteur());
 
-        $this->client->request('POST', "/api/agent/fip6/dossier/{$dossier->getId()}/marquer-indemnise");
+        // TODO tester avec une date invalide
+        $this->client->request('POST', "/api/agent/fip6/dossier/{$dossier->getId()}/marquer-indemnise", [
+            'dateIndemnisation' => $dateIndemnisationEnvoyee->format('Y-m-d'),
+        ]);
 
         $this->assertTrue($this->client->getResponse()->isOk());
 
         $this->em->refresh($dossier);
 
         $this->assertEquals(EtatDossierType::DOSSIER_OK_INDEMNISE, $dossier->getEtatDossier()->getEtat());
+        $this->assertEquals($dossier->getRedacteur(), $dossier->getEtatDossier()->getAgent());
+        $this->assertEquals($dateIndemnisationAttendue->format('Y-m-d'), $dossier->getEtatDossier()->getDate()->format('Y-m-d'));
     }
 
     /**
      * ETQ agent de liaison, je dois pouvoir marquer le dossier comme indemnisé.
      */
-    public function testMarquerDossierIndemniseAgentLiaisonOk()
+    #[DataProvider('donnesMarquerDossierIndemnise')]
+    public function testMarquerDossierIndemniseAgentLiaisonOk(callable $calculerDateIndemnisationEnvoyee, callable $calculerDateIndemnisationAttendue)
     {
         $dossier = $this->getDossierParEtat(EtatDossierType::DOSSIER_OK_EN_ATTENTE_PAIEMENT);
+        /** @var \DateTime $dateIndemnisationEnvoyee */
+        $dateIndemnisationEnvoyee = $calculerDateIndemnisationEnvoyee($dossier->getEtatDossier());
+        /** @var \DateTime $dateIndemnisationAttendue */
+        $dateIndemnisationAttendue = $calculerDateIndemnisationAttendue($dossier->getEtatDossier());
 
-        $this->connexion('liaison@justice.gouv.fr');
+        $agent = $this->connexion('liaison@justice.gouv.fr');
 
-        $this->client->request('POST', "/api/agent/fip6/dossier/{$dossier->getId()}/marquer-indemnise");
+        $this->client->request('POST', "/api/agent/fip6/dossier/{$dossier->getId()}/marquer-indemnise", [
+            'dateIndemnisation' => $dateIndemnisationEnvoyee->format('Y-m-d'),
+        ]);
 
         $this->assertTrue($this->client->getResponse()->isOk());
 
         $this->em->refresh($dossier);
 
         $this->assertEquals(EtatDossierType::DOSSIER_OK_INDEMNISE, $dossier->getEtatDossier()->getEtat());
+        $this->assertEquals($agent, $dossier->getEtatDossier()->getAgent());
+        $this->assertEquals($dateIndemnisationAttendue->format('Y-m-d'), $dossier->getEtatDossier()->getDate()->format('Y-m-d'));
     }
 }

--- a/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/MarquerDossierIndemniseEndpointTest.php
+++ b/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/MarquerDossierIndemniseEndpointTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Api\Agent\Fip6\Dossier\Endpoint;
+
+use MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Dossier\MarquerDossierIndemniseEndpoint;
+use MonIndemnisationJustice\Entity\EtatDossierType;
+use MonIndemnisationJustice\Tests\Api\Agent\Fip6\AbstractEndpointTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(MarquerDossierIndemniseEndpoint::class)]
+class MarquerDossierIndemniseEndpointTest extends AbstractEndpointTestCase
+{
+    /**
+     * ETQ rédacteur du dossier, je dois pouvoir marquer le dossier comme indemnisé.
+     */
+    public function testMarquerDossierIndemniseRedacteurOk()
+    {
+        $dossier = $this->getDossierParEtat(EtatDossierType::DOSSIER_OK_EN_ATTENTE_PAIEMENT);
+
+        $this->connexionAgent($dossier->getRedacteur());
+
+        $this->client->request('POST', "/api/agent/fip6/dossier/{$dossier->getId()}/marquer-indemnise");
+
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        $this->em->refresh($dossier);
+
+        $this->assertEquals(EtatDossierType::DOSSIER_OK_INDEMNISE, $dossier->getEtatDossier()->getEtat());
+    }
+
+    /**
+     * ETQ agent de liaison, je dois pouvoir marquer le dossier comme indemnisé.
+     */
+    public function testMarquerDossierIndemniseAgentLiaisonOk()
+    {
+        $dossier = $this->getDossierParEtat(EtatDossierType::DOSSIER_OK_EN_ATTENTE_PAIEMENT);
+
+        $this->connexion('liaison@justice.gouv.fr');
+
+        $this->client->request('POST', "/api/agent/fip6/dossier/{$dossier->getId()}/marquer-indemnise");
+
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        $this->em->refresh($dossier);
+
+        $this->assertEquals(EtatDossierType::DOSSIER_OK_INDEMNISE, $dossier->getEtatDossier()->getEtat());
+    }
+}

--- a/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/TransmettreAFIP3EndpointTest.php
+++ b/backend/tests/Api/Agent/Fip6/Dossier/Endpoint/TransmettreAFIP3EndpointTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Api\Agent\Fip6\Dossier\Endpoint;
+
+use MonIndemnisationJustice\Api\Agent\Fip6\Endpoint\Dossier\TransmettreAFIP3Endpoint;
+use MonIndemnisationJustice\Entity\EtatDossierType;
+use MonIndemnisationJustice\Tests\Api\Agent\Fip6\AbstractEndpointTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(TransmettreAFIP3Endpoint::class)]
+class TransmettreAFIP3EndpointTest extends AbstractEndpointTestCase
+{
+    /**
+     * ETQ rédacteur du dossier, je dois pouvoir transmettre le dossier à FIP3.
+     */
+    public function testTransmettreAFIP3RedacteurOk()
+    {
+        $dossier = $this->getDossierParEtat(EtatDossierType::DOSSIER_OK_A_INDEMNISER);
+
+        $this->connexionAgent($dossier->getRedacteur());
+
+        $this->client->request('POST', "/api/agent/fip6/dossier/{$dossier->getId()}/transmettre-a-fip3");
+
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        $this->em->refresh($dossier);
+
+        $this->assertEquals(EtatDossierType::DOSSIER_OK_EN_ATTENTE_PAIEMENT, $dossier->getEtatDossier()->getEtat());
+    }
+
+    /**
+     * ETQ agent de liaison, je dois pouvoir transmettre le dossier à FIP3.
+     */
+    public function testTransmettreAFIP3AgentLiaisonOk()
+    {
+        $dossier = $this->getDossierParEtat(EtatDossierType::DOSSIER_OK_A_INDEMNISER);
+
+        $this->connexion('liaison@justice.gouv.fr');
+
+        $this->client->request('POST', "/api/agent/fip6/dossier/{$dossier->getId()}/transmettre-a-fip3");
+
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        $this->em->refresh($dossier);
+
+        $this->assertEquals(EtatDossierType::DOSSIER_OK_EN_ATTENTE_PAIEMENT, $dossier->getEtatDossier()->getEtat());
+    }
+}

--- a/frontend/src/apps/agent/fdo/routes/bris-de-porte/mes-declarations.tsx
+++ b/frontend/src/apps/agent/fdo/routes/bris-de-porte/mes-declarations.tsx
@@ -57,12 +57,14 @@ const Page = () => {
                   sauvegardé le{" "}
                   {dateSimple(
                     declaration.dateSoumission ?? declaration.dateCreation,
-                    true,
+                    { masquerAnneeSiCourante: true },
                   )}
                 </>
               ),
               declaration.dateOperation ? (
-                dateSimple(declaration.dateOperation, true)
+                dateSimple(declaration.dateOperation, {
+                  masquerAnneeSiCourante: true,
+                })
               ) : (
                 <i>Non renseignée</i>
               ),

--- a/frontend/src/apps/agent/fip6/dossiers/components/ListeDossierATransmettre.tsx
+++ b/frontend/src/apps/agent/fip6/dossiers/components/ListeDossierATransmettre.tsx
@@ -52,8 +52,9 @@ function DossierATransmettreLigne({
               children: "Télécharger",
               className: "fr-mb-0",
               linkProps: {
-                href: `${window.location.origin}/agent/redacteur/${dossier.id}/documents-a-transmettre`,
+                href: `${window.location.origin}/agent/document/dossier/${dossier.id}/documents-a-transmettre`,
                 target: "_self",
+                download: true,
               },
             },
             {

--- a/frontend/src/apps/agent/fip6/dossiers/components/consultation/InfosDossier.tsx
+++ b/frontend/src/apps/agent/fip6/dossiers/components/consultation/InfosDossier.tsx
@@ -149,7 +149,7 @@ export const InfosDossier = ({
               <li>
                 <b>Le :</b>{" "}
                 {dossier.dateOperation ? (
-                  <>{dateSimple(dossier.dateOperation, false)}</>
+                  <>{dateSimple(dossier.dateOperation)}</>
                 ) : (
                   <i>non renseigné</i>
                 )}

--- a/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/DossierActions.tsx
+++ b/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/DossierActions.tsx
@@ -28,12 +28,12 @@ import { ButtonProps } from "@codegouvfr/react-dsfr/Button";
 import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 import React from "react";
 import {
-  attribuerBoutons,
   AttribuerModale as AttribuerActionModale,
+  attribuerBoutons,
 } from "./AttributionAction.tsx";
 import {
-  cloturerBoutons,
   CloturerModale as CloturerActionModale,
+  cloturerBoutons,
 } from "./CloturerAction.tsx";
 import {
   signerArretePaiementBoutons,
@@ -45,15 +45,15 @@ export const DossierActions = function DossierActionBar({
   agent,
   redacteurs,
   onDecide,
-  onEdite,
   onSigne,
+  onTermine,
 }: {
   dossier: DossierDetail;
   agent: Agent;
   redacteurs: Redacteur[];
   onDecide?: () => void;
-  onEdite?: () => void;
   onSigne?: () => void;
+  onTermine: () => void | Promise<void>;
 }) {
   return (
     <>
@@ -102,8 +102,16 @@ export const DossierActions = function DossierActionBar({
       <SignerCourrierModale dossier={dossier} agent={agent} onSigne={onSigne} />
       <GenererArretePaiementModale dossier={dossier} agent={agent} />
       <SignerArretePaiementModale dossier={dossier} agent={agent} />
-      <EnvoyerPourIndemnisationActionModale dossier={dossier} agent={agent} />
-      <MarquerIndemniseActionModale dossier={dossier} agent={agent} />
+      <EnvoyerPourIndemnisationActionModale
+        dossier={dossier}
+        agent={agent}
+        onTermine={onTermine}
+      />
+      <MarquerIndemniseActionModale
+        dossier={dossier}
+        agent={agent}
+        onTermine={onTermine}
+      />
     </>
   );
 };

--- a/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/EnvoyerPourIndemnisationActionModale.tsx
+++ b/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/EnvoyerPourIndemnisationActionModale.tsx
@@ -1,17 +1,13 @@
+import { DossierManagerInterface } from "@/apps/agent/fip6/services/dossier";
+import { Agent, DossierDetail, EtatDossierType } from "@/common/models";
+import { ButtonProps } from "@codegouvfr/react-dsfr/Button";
+import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
+import Download from "@codegouvfr/react-dsfr/Download";
 import { createModal } from "@codegouvfr/react-dsfr/Modal";
-import {
-  Agent,
-  DossierDetail,
-  EtatDossier,
-  EtatDossierType,
-} from "@/common/models";
+import { ToggleSwitch } from "@codegouvfr/react-dsfr/ToggleSwitch";
+import { useInjection } from "inversify-react";
 import { observer } from "mobx-react-lite";
 import React, { useCallback, useState } from "react";
-import { ButtonProps } from "@codegouvfr/react-dsfr/Button";
-import Download from "@codegouvfr/react-dsfr/Download";
-import { ToggleSwitch } from "@codegouvfr/react-dsfr/ToggleSwitch";
-import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
-import { plainToInstance } from "class-transformer";
 
 const _modale = createModal({
   id: "modale-action-envoyer-pour-indemnisation",
@@ -25,16 +21,22 @@ const estAEnvoyerPourIndemnisation = ({
   dossier: DossierDetail;
   agent: Agent;
 }): boolean =>
-  agent.estLiaisonBudget() &&
+  (agent.instruit(dossier) || agent.estLiaisonBudget()) &&
   dossier.etat.etat === EtatDossierType.OK_A_INDEMNISER;
 
 const component = observer(function EnvoyerPourIndemnisationActionModale({
   dossier,
   agent,
+  onTermine,
 }: {
   dossier: DossierDetail;
   agent: Agent;
+  onTermine: () => void | Promise<void>;
 }) {
+  const dossierManager = useInjection<DossierManagerInterface>(
+    DossierManagerInterface.$,
+  );
+
   // Indique si la sauvegarde du rédacteur attribué est en cours (le cas échéant affiche un message explicit et bloque les boutons)
   const [sauvegardeEnCours, setSauvegarderEnCours]: [
     boolean,
@@ -50,22 +52,9 @@ const component = observer(function EnvoyerPourIndemnisationActionModale({
   const envoyerPourIndemnisation = useCallback(async () => {
     setSauvegarderEnCours(true);
 
-    const response = await fetch(
-      `/agent/redacteur/dossier/${dossier.id}/envoyer-pour-indemnisation.json`,
-      {
-        method: "POST",
-        headers: {
-          "Content-type": "application/json",
-          Accept: "application/json",
-        },
-      },
-    );
+    await dossierManager.transmettreAFIP3(dossier);
 
-    if (response.ok) {
-      const data = await response.json();
-      dossier.changerEtat(plainToInstance(EtatDossier, data.etat));
-    }
-
+    await onTermine();
     _modale.close();
     setSauvegarderEnCours(false);
   }, [dossier.id]);
@@ -86,7 +75,9 @@ const component = observer(function EnvoyerPourIndemnisationActionModale({
         label="Télécharger les documents à transmettre"
         details="Arrêté de paiement, RIB, pièce d'identité"
         linkProps={{
-          href: `/agent/redacteur/${dossier.id}/documents-a-transmettre`,
+          href: `${document.location.origin}/agent/document/dossier/${dossier.id}/documents-a-transmettre`,
+          target: "_self",
+          download: true,
         }}
       />
 

--- a/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/MarquerIndemniseActionModale.tsx
+++ b/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/MarquerIndemniseActionModale.tsx
@@ -1,7 +1,9 @@
 import { DossierManagerInterface } from "@/apps/agent/fip6/services/dossier";
 import { Agent, DossierDetail, EtatDossierType } from "@/common/models";
+import { dateChiffre, dateSimple } from "@/common/services/date.ts";
 import { ButtonProps } from "@codegouvfr/react-dsfr/Button";
 import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
+import { Input } from "@codegouvfr/react-dsfr/Input";
 import { createModal } from "@codegouvfr/react-dsfr/Modal";
 import { useInjection } from "inversify-react";
 import { observer } from "mobx-react-lite";
@@ -36,6 +38,10 @@ const component = observer(function EnvoyerPourIndemnisationActionModale({
     DossierManagerInterface.$,
   );
 
+  const [dateIndemnisation, setDateIndemnisation] = useState<Date>(
+    dossier.etat.dateEntree,
+  );
+
   // Indique si la sauvegarde du rédacteur attribué est en cours (le cas échéant affiche un message explicit et bloque les boutons)
   const [sauvegardeEnCours, setSauvegarderEnCours]: [
     boolean,
@@ -44,7 +50,7 @@ const component = observer(function EnvoyerPourIndemnisationActionModale({
 
   const marquerIndemnise = useCallback(async () => {
     setSauvegarderEnCours(true);
-    await dossierManager.marquerIndemnise(dossier);
+    await dossierManager.marquerIndemnise(dossier, dateIndemnisation);
     await onTermine();
 
     _modale.close();
@@ -59,11 +65,9 @@ const component = observer(function EnvoyerPourIndemnisationActionModale({
     >
       <p>
         Ce dossier a été transmis au Bureau du Budget le{" "}
-        {dossier.etat.dateEntree.toLocaleString("fr-FR", {
-          weekday: "long",
-          day: "numeric",
-          month: "long",
-          year: "numeric",
+        {dateSimple(dossier.etat.dateEntree, {
+          masquerAnneeSiCourante: true,
+          jourDeLaSemaine: true,
         })}
         .
       </p>
@@ -72,6 +76,17 @@ const component = observer(function EnvoyerPourIndemnisationActionModale({
         Si vous avez été notifié du versement de l'indemnité, vous pouvez
         marquer le dossier comme indemnisé.
       </p>
+
+      <Input
+        label="Date du virement"
+        nativeInputProps={{
+          type: "date",
+          defaultValue: dateChiffre(dateIndemnisation),
+          onChange: (e) => setDateIndemnisation(new Date(e.target.value)),
+          min: dateChiffre(dossier.etat.dateEntree),
+          max: dateChiffre(new Date()),
+        }}
+      />
 
       <ButtonsGroup
         inlineLayoutWhen="always"
@@ -89,7 +104,10 @@ const component = observer(function EnvoyerPourIndemnisationActionModale({
             children: "Marquer indemnisé",
             iconId: "fr-icon-check-line",
             priority: "primary",
-            disabled: sauvegardeEnCours,
+            disabled:
+              sauvegardeEnCours ||
+              dateIndemnisation < dossier.etat.dateEntree ||
+              dateIndemnisation > new Date(),
             onClick: async () => marquerIndemnise(),
           },
         ]}

--- a/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/MarquerIndemniseActionModale.tsx
+++ b/frontend/src/apps/agent/fip6/dossiers/components/consultation/action/MarquerIndemniseActionModale.tsx
@@ -1,15 +1,11 @@
-import { createModal } from "@codegouvfr/react-dsfr/Modal";
-import {
-  Agent,
-  DossierDetail,
-  EtatDossier,
-  EtatDossierType,
-} from "@/common/models";
-import { observer } from "mobx-react-lite";
-import React, { useCallback, useState } from "react";
+import { DossierManagerInterface } from "@/apps/agent/fip6/services/dossier";
+import { Agent, DossierDetail, EtatDossierType } from "@/common/models";
 import { ButtonProps } from "@codegouvfr/react-dsfr/Button";
 import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
-import { plainToInstance } from "class-transformer";
+import { createModal } from "@codegouvfr/react-dsfr/Modal";
+import { useInjection } from "inversify-react";
+import { observer } from "mobx-react-lite";
+import React, { useCallback, useState } from "react";
 
 const _modale = createModal({
   id: "modale-action-emarquer-indemnise",
@@ -23,16 +19,23 @@ const estEnAttenteIndemnisation = ({
   dossier: DossierDetail;
   agent: Agent;
 }): boolean =>
-  agent.estLiaisonBudget() &&
-  dossier.etat.etat === EtatDossierType.OK_EN_ATTENTE_PAIEMENT;
+  agent.estLiaisonBudget() ||
+  (agent.instruit(dossier) &&
+    dossier.etat.etat === EtatDossierType.OK_EN_ATTENTE_PAIEMENT);
 
 const component = observer(function EnvoyerPourIndemnisationActionModale({
   dossier,
   agent,
+  onTermine,
 }: {
   dossier: DossierDetail;
   agent: Agent;
+  onTermine: () => void | Promise<void>;
 }) {
+  const dossierManager = useInjection<DossierManagerInterface>(
+    DossierManagerInterface.$,
+  );
+
   // Indique si la sauvegarde du rédacteur attribué est en cours (le cas échéant affiche un message explicit et bloque les boutons)
   const [sauvegardeEnCours, setSauvegarderEnCours]: [
     boolean,
@@ -41,22 +44,8 @@ const component = observer(function EnvoyerPourIndemnisationActionModale({
 
   const marquerIndemnise = useCallback(async () => {
     setSauvegarderEnCours(true);
-
-    const response = await fetch(
-      `/agent/redacteur/dossier/${dossier.id}/marquer-indemnise.json`,
-      {
-        method: "POST",
-        headers: {
-          "Content-type": "application/json",
-          Accept: "application/json",
-        },
-      },
-    );
-
-    if (response.ok) {
-      const data = await response.json();
-      dossier.changerEtat(plainToInstance(EtatDossier, data.etat));
-    }
+    await dossierManager.marquerIndemnise(dossier);
+    await onTermine();
 
     _modale.close();
     setSauvegarderEnCours(false);

--- a/frontend/src/apps/agent/fip6/routes/__root.tsx
+++ b/frontend/src/apps/agent/fip6/routes/__root.tsx
@@ -229,7 +229,7 @@ const EspaceRedacteur = () => {
                 {
                   text: (
                     <>
-                      À vérifier
+                      Arrêté à éditer
                       <Badge
                         as={"p"}
                         small={true}
@@ -265,8 +265,8 @@ const EspaceRedacteur = () => {
                 },
               ]
             : []),
-          // Liste des dossiers à synchroniser avec FIP3 (si LIAISON_BUDGET)
-          ...(agent.aRole(RoleAgent.LIAISON_BUDGET)
+          // Liste des dossiers à synchroniser avec FIP3 (si LIAISON_BUDGET ou rédacteur)
+          ...(agent.aRole(RoleAgent.LIAISON_BUDGET) || agent.estRedacteur()
             ? [
                 {
                   text: (

--- a/frontend/src/apps/agent/fip6/routes/dossier/$id/index.tsx
+++ b/frontend/src/apps/agent/fip6/routes/dossier/$id/index.tsx
@@ -6,17 +6,28 @@ import { QuillEditor } from "@/apps/agent/fip6/dossiers/components/consultation/
 import { InfosDossier } from "@/apps/agent/fip6/dossiers/components/consultation/InfosDossier";
 import {
   ChampPieceJointe,
-  TelechargerPieceJointe
+  TelechargerPieceJointe,
 } from "@/apps/agent/fip6/dossiers/components/consultation/piecejointe";
 import { PiecesJointes } from "@/apps/agent/fip6/dossiers/components/consultation/PiecesJointes";
 import { DossierManagerInterface } from "@/apps/agent/fip6/services/dossier";
 import { Frise } from "@/common/composants/Frise.tsx";
-import { Agent, Document, DossierDetail, EtatDossier, Redacteur } from "@/common/models";
+import {
+  Agent,
+  Document,
+  DossierDetail,
+  EtatDossier,
+  Redacteur,
+} from "@/common/models";
 import { AgentManagerInterface } from "@/common/services/agent/agent.ts";
 import { dateEtHeureSimple } from "@/common/services/date";
 import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 import Tabs from "@codegouvfr/react-dsfr/Tabs";
-import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  Link,
+  notFound,
+  useRouter,
+} from "@tanstack/react-router";
 import { observer } from "mobx-react-lite";
 import React, { useMemo, useState } from "react";
 
@@ -69,6 +80,8 @@ const ConsultationDossier = observer(function ConsultationDossier({
   agent: Agent;
   redacteurs: Redacteur[];
 }) {
+  const routeur = useRouter();
+
   // Référence vers l'onglet ouvert
   const [selectedTab, selectTab] = useState(
     window.location.hash?.replace(/^#/, "") || "infos",
@@ -192,8 +205,8 @@ const ConsultationDossier = observer(function ConsultationDossier({
                 agent={agent}
                 redacteurs={redacteurs}
                 onDecide={() => ouvrirSectionCourrier()}
-                onEdite={() => ouvrirSectionCourrier()}
                 onSigne={() => ouvrirSectionCourrier()}
+                onTermine={async () => await routeur.invalidate()}
               />
 
               {/* L'agent validateur génère et signe l'arrêté de paiement */}

--- a/frontend/src/apps/agent/fip6/services/dossier.ts
+++ b/frontend/src/apps/agent/fip6/services/dossier.ts
@@ -1,5 +1,12 @@
 import { queryClient } from "@/apps/agent/fip6/query.ts";
-import { Agent, BaseDossier, Document, DocumentType, DossierDetail } from "@/common/models";
+import {
+  Agent,
+  BaseDossier,
+  Document,
+  DocumentType,
+  DossierDetail,
+  EtatDossier,
+} from "@/common/models";
 import { RoleAgent } from "@/common/models/Agent.ts";
 import { plainToInstance } from "class-transformer";
 import { ServiceIdentifier } from "inversify";
@@ -28,6 +35,10 @@ export interface DossierManagerInterface {
     type: DocumentType,
     fichier: File,
   ): Promise<Document>;
+
+  transmettreAFIP3(dossier: BaseDossier): Promise<void>;
+
+  marquerIndemnise(dossier: BaseDossier): Promise<void>;
 }
 
 export namespace DossierManagerInterface {
@@ -95,5 +106,43 @@ export class APIDossierManager implements DossierManagerInterface {
       data?.erreur ??
         "Une erreur est survenue lors de l'envoi de la pièce jointe",
     );
+  }
+
+  async transmettreAFIP3(dossier: BaseDossier): Promise<void> {
+    const response = await fetch(
+      `/agent/redacteur/dossier/${dossier.id}/envoyer-pour-indemnisation.json`,
+      {
+        method: "POST",
+        headers: {
+          "Content-type": "application/json",
+          Accept: "application/json",
+        },
+      },
+    );
+
+    if (response.ok) {
+      const data = await response.json();
+      // TODO arrêter ça, à la place gérer un cache sur le dossier et le mettre à jour
+      dossier.changerEtat(plainToInstance(EtatDossier, data.etat));
+    }
+  }
+
+  async marquerIndemnise(dossier: BaseDossier): Promise<void> {
+    const response = await fetch(
+      `/agent/redacteur/dossier/${dossier.id}/marquer-indemnise.json`,
+      {
+        method: "POST",
+        headers: {
+          "Content-type": "application/json",
+          Accept: "application/json",
+        },
+      },
+    );
+
+    if (response.ok) {
+      const data = await response.json();
+      // TODO arrêter ça, à la place gérer un cache sur le dossier et le mettre à jour
+      dossier.changerEtat(plainToInstance(EtatDossier, data.etat));
+    }
   }
 }

--- a/frontend/src/apps/agent/fip6/services/dossier.ts
+++ b/frontend/src/apps/agent/fip6/services/dossier.ts
@@ -1,12 +1,7 @@
 import { queryClient } from "@/apps/agent/fip6/query.ts";
-import {
-  Agent,
-  BaseDossier,
-  Document,
-  DocumentType,
-  DossierDetail,
-} from "@/common/models";
+import { Agent, BaseDossier, Document, DocumentType, DossierDetail } from "@/common/models";
 import { RoleAgent } from "@/common/models/Agent.ts";
+import { dateChiffre } from "@/common/services/date.ts";
 import { plainToInstance } from "class-transformer";
 import { ServiceIdentifier } from "inversify";
 
@@ -37,7 +32,10 @@ export interface DossierManagerInterface {
 
   transmettreAFIP3(dossier: BaseDossier): Promise<void>;
 
-  marquerIndemnise(dossier: BaseDossier): Promise<void>;
+  marquerIndemnise(
+    dossier: BaseDossier,
+    dateIndemnisation: Date,
+  ): Promise<void>;
 }
 
 export namespace DossierManagerInterface {
@@ -143,11 +141,17 @@ export class APIDossierManager implements DossierManagerInterface {
     }
   }
 
-  async marquerIndemnise(dossier: BaseDossier): Promise<void> {
+  async marquerIndemnise(
+    dossier: BaseDossier,
+    dateIndemnisation: Date,
+  ): Promise<void> {
     const reponse = await fetch(
       `/api/agent/fip6/dossier/${dossier.id}/marquer-indemnise`,
       {
         method: "POST",
+        body: JSON.stringify({
+          dateIndemnisation: dateChiffre(dateIndemnisation),
+        }),
         headers: {
           "Content-type": "application/json",
           Accept: "application/json",

--- a/frontend/src/apps/agent/fip6/services/dossier.ts
+++ b/frontend/src/apps/agent/fip6/services/dossier.ts
@@ -5,7 +5,6 @@ import {
   Document,
   DocumentType,
   DossierDetail,
-  EtatDossier,
 } from "@/common/models";
 import { RoleAgent } from "@/common/models/Agent.ts";
 import { plainToInstance } from "class-transformer";
@@ -68,16 +67,33 @@ export class APIDossierManager implements DossierManagerInterface {
     });
   }
 
+  protected recupererDossier(id: number): Promise<DossierDetail> {
+    return queryClient.fetchQuery<DossierDetail>({
+      queryKey: ["DossierManagerInterface", "dossier", id],
+      queryFn: async (): Promise<DossierDetail> => {
+        const reponse = await fetch(`/api/agent/fip6/dossier/${id}`);
+
+        if (!reponse.ok) {
+          throw new Error(`Failed to fetch dossier: ${reponse.status}`);
+        }
+
+        const donnees = await reponse.json();
+
+        return plainToInstance(DossierDetail, donnees);
+      },
+      staleTime: 5 * 60 * 1000, // 5 minutes
+    });
+  }
+
+  protected enregistrerDossier(dossier: DossierDetail): void {
+    queryClient.setQueryData(
+      ["DossierManagerInterface", "dossier", dossier.id],
+      () => dossier,
+    );
+  }
+
   async consulter(id: number): Promise<DossierDetail> {
-    const reponse = await fetch(`/api/agent/fip6/dossier/${id}`);
-
-    if (!reponse.ok) {
-      throw new Error(`Failed to fetch dossier: ${reponse.status}`);
-    }
-
-    const data = await reponse.json();
-
-    return plainToInstance(DossierDetail, data);
+    return this.recupererDossier(id);
   }
 
   async ajouterPieceJointe(
@@ -109,8 +125,8 @@ export class APIDossierManager implements DossierManagerInterface {
   }
 
   async transmettreAFIP3(dossier: BaseDossier): Promise<void> {
-    const response = await fetch(
-      `/agent/redacteur/dossier/${dossier.id}/envoyer-pour-indemnisation.json`,
+    const reponse = await fetch(
+      `/api/agent/fip6/dossier/${dossier.id}/transmettre-a-fip3`,
       {
         method: "POST",
         headers: {
@@ -120,16 +136,16 @@ export class APIDossierManager implements DossierManagerInterface {
       },
     );
 
-    if (response.ok) {
-      const data = await response.json();
-      // TODO arrêter ça, à la place gérer un cache sur le dossier et le mettre à jour
-      dossier.changerEtat(plainToInstance(EtatDossier, data.etat));
+    if (reponse.ok) {
+      const donnees = await reponse.json();
+
+      this.enregistrerDossier(plainToInstance(DossierDetail, donnees));
     }
   }
 
   async marquerIndemnise(dossier: BaseDossier): Promise<void> {
-    const response = await fetch(
-      `/agent/redacteur/dossier/${dossier.id}/marquer-indemnise.json`,
+    const reponse = await fetch(
+      `/api/agent/fip6/dossier/${dossier.id}/marquer-indemnise`,
       {
         method: "POST",
         headers: {
@@ -139,10 +155,10 @@ export class APIDossierManager implements DossierManagerInterface {
       },
     );
 
-    if (response.ok) {
-      const data = await response.json();
-      // TODO arrêter ça, à la place gérer un cache sur le dossier et le mettre à jour
-      dossier.changerEtat(plainToInstance(EtatDossier, data.etat));
+    if (reponse.ok) {
+      const donnees = await reponse.json();
+
+      this.enregistrerDossier(plainToInstance(DossierDetail, donnees));
     }
   }
 }

--- a/frontend/src/common/composants/Frise.tsx
+++ b/frontend/src/common/composants/Frise.tsx
@@ -24,14 +24,6 @@ const FriseContenu = ({
   alignDroit?: boolean;
   afficherDuree?: boolean;
 }) => {
-  console.log(
-    afficherDuree,
-    evenement.dateFin,
-    afficherDuree && !!evenement.dateFin,
-    afficherDuree && !!evenement.dateFin
-      ? periode(evenement.date, evenement.dateFin)
-      : undefined,
-  );
   return (
     <div
       className={`frise__contenu${alignDroit ? " frise__contenu--aligne-droite" : ""}`}

--- a/frontend/src/common/services/date.ts
+++ b/frontend/src/common/services/date.ts
@@ -78,9 +78,16 @@ export const dateChiffre = function (date?: Date): string {
  *  */
 export const dateSimple = function (
   date: Date,
-  masquerAnneeSiCourante: boolean = false,
+  {
+    masquerAnneeSiCourante = false,
+    jourDeLaSemaine = false,
+  }: { masquerAnneeSiCourante?: boolean; jourDeLaSemaine?: boolean } = {
+    masquerAnneeSiCourante: false,
+    jourDeLaSemaine: false,
+  },
 ): string {
   return date.toLocaleString("fr-FR", {
+    weekday: jourDeLaSemaine ? "long" : undefined,
     day: "numeric",
     month: "long",
     year:
@@ -142,5 +149,5 @@ export const dateEtHeureSimple = function (
     return "";
   }
 
-  return `${dateSimple(date, masquerAnneeSiCourante)} à ${avecMinutes ? heureEtMinutesSimple(date, { litterale }) : heureSimple(date, { litterale })}`;
+  return `${dateSimple(date, { masquerAnneeSiCourante })} à ${avecMinutes ? heureEtMinutesSimple(date, { litterale }) : heureSimple(date, { litterale })}`;
 };


### PR DESCRIPTION
# Permettre au rédacteur de transmettre à fip3 ses dossiers

Il est donc notifié, peut transmettre lui-même et marquer comme indemnisé. L'agent de liaison peut toujours le faire, sur tous les dossiers, mais n'est plus notifié.

