### PR TITLE
Réviser les libellés du tunnel de test d'éligibilité dysfonctionnement

### DIFF
--- a/backend/src/Api/Public/Dysfonctionnement/Input/TestEligibiliteDysfonctionnementInput.php
+++ b/backend/src/Api/Public/Dysfonctionnement/Input/TestEligibiliteDysfonctionnementInput.php
@@ -39,7 +39,7 @@ class TestEligibiliteDysfonctionnementInput
     #[Assert\Count(min: 1, minMessage: 'Veuillez sélectionner au moins une pièce de procédure')]
     #[Assert\All([
         new Assert\Choice(
-            choices: ['acte_introductif', 'ecritures', 'convocations', 'echanges', 'documents_procedure'],
+            choices: ['acte_introductif', 'ecritures', 'echanges', 'documents_procedure'],
             message: 'Pièce de procédure invalide'
         ),
     ])]

--- a/backend/src/Entity/PieceProcedure.php
+++ b/backend/src/Entity/PieceProcedure.php
@@ -6,7 +6,6 @@ enum PieceProcedure: string
 {
     case ACTE_INTRODUCTIF = 'acte_introductif';
     case ECRITURES = 'ecritures';
-    case CONVOCATIONS = 'convocations';
     case ECHANGES = 'echanges';
     case DOCUMENTS_PROCEDURE = 'documents_procedure';
     case AUCUNE = 'aucune';

--- a/frontend/src/apps/public/components/Layout.tsx
+++ b/frontend/src/apps/public/components/Layout.tsx
@@ -43,7 +43,7 @@ export const Layout = ({ children }: Props) => {
 
     <Footer
       accessibility="non compliant"
-      contentDescription="Mon Indemnisation Justice est un service public numérique du Ministère de la Justice permettant de déclarer un déni de justice et de suivre votre dossier d'indemnisation."
+      contentDescription="Mon Indemnisation Justice est un service public numérique du Ministère de la Justice permettant de déclarer un délai déraisonnable de procédure et de suivre votre dossier d'indemnisation."
       bottomItems={[headerFooterDisplayItem]}
       termsLinkProps={{ href: "/mentions-legales" }}
     />

--- a/frontend/src/apps/public/components/formulaires/eligibilite.schemas.ts
+++ b/frontend/src/apps/public/components/formulaires/eligibilite.schemas.ts
@@ -12,7 +12,6 @@ const valeursTypeDecision = [
 const valeursPieceProcedure = [
   PieceProcedure.ActeIntroductif,
   PieceProcedure.Ecritures,
-  PieceProcedure.Convocations,
   PieceProcedure.Echanges,
   PieceProcedure.DocumentsProcedure,
 ] as const;

--- a/frontend/src/apps/public/components/steps/StepActionContentieuse.tsx
+++ b/frontend/src/apps/public/components/steps/StepActionContentieuse.tsx
@@ -89,7 +89,7 @@ export function StepActionContentieuse({
               <Alert
                 className="fr-mt-2w"
                 severity="error"
-                title="Démarche irrecevable"
+                title="Vous n'êtes pas éligible à déposer un dossier"
                 description="Une procédure contentieuse en cours devant l'AJE rend la démarche précontentieuse irrecevable."
               />
             );

--- a/frontend/src/apps/public/components/steps/StepDateDecision.tsx
+++ b/frontend/src/apps/public/components/steps/StepDateDecision.tsx
@@ -82,35 +82,6 @@ export function StepDateDecision({
         </div>
       </div>
 
-      <p
-        className="fr-text--sm fr-mt-2w"
-        style={{ color: "var(--text-default-info)" }}
-      >
-        <span
-          className="fr-icon-information-line fr-icon--sm"
-          aria-hidden="true"
-        />{" "}
-        La prescription est quadriennale : vous disposez de 4 ans à compter du
-        1er janvier de l'année suivant celle de la décision pour agir.
-      </p>
-
-      <Accordion
-        label="Référence juridique et exemple"
-        className="fr-mt-2w fr-mb-2w"
-      >
-        <div className="fr-callout">
-          <p className="fr-text--sm">
-            Référence juridique : Art. 1er, loi n°68-1250 du 31/12/1968 — Civ.
-            1re, 15/06/2017, n°16-18.769
-          </p>
-          <p className="fr-text--sm fr-mb-0">
-            Exemple : Décision rendue le 15 mars {annee} → délai du 1er janvier{" "}
-            {annee + 1} au 31 décembre {annee + 4}. Au 1er janvier {annee + 5},
-            l'action est prescrite.
-          </p>
-        </div>
-      </Accordion>
-
       <formulaire.Subscribe
         selector={(state) => ({
           dateDecision: state.values.dateDecision,
@@ -135,7 +106,7 @@ export function StepDateDecision({
                 title={
                   prescription.rempli
                     ? "Vous êtes dans les délais"
-                    : "Le délai de prescription dépassé"
+                    : "Le délai de prescription est dépassé"
                 }
                 description={prescription.detail}
               />
@@ -144,6 +115,36 @@ export function StepDateDecision({
           return null;
         }}
       />
+
+      <p
+        className="fr-text--sm fr-mt-2w"
+        style={{ color: "var(--text-default-info)" }}
+      >
+        <span
+          className="fr-icon-information-line fr-icon--sm"
+          aria-hidden="true"
+        />{" "}
+        La prescription est quadriennale : vous disposez de 4 ans à compter du
+        1er janvier de l'année suivant celle de la décision pour effectuer une
+        demande d'indemnisation suite à un délai déraisonnable de procédure.
+      </p>
+
+      <Accordion
+        label="Référence juridique et exemple"
+        className="fr-mt-2w fr-mb-2w"
+      >
+        <div className="fr-callout">
+          <p className="fr-text--sm">
+            Référence juridique : Art. 1er, loi n°68-1250 du 31/12/1968 — Civ.
+            1re, 15/06/2017, n°16-18.769
+          </p>
+          <p className="fr-text--sm fr-mb-0">
+            Exemple : Décision rendue le 15 mars {annee} → délai du 1er janvier{" "}
+            {annee + 1} au 31 décembre {annee + 4}. Au 1er janvier {annee + 5},
+            l'action est prescrite.
+          </p>
+        </div>
+      </Accordion>
 
       {dateDecision && !prescription.rempli && onRetour ? (
         <BlockedNavButtons onRetour={onRetour} />

--- a/frontend/src/apps/public/components/steps/StepPiecesProc.tsx
+++ b/frontend/src/apps/public/components/steps/StepPiecesProc.tsx
@@ -14,20 +14,18 @@ import { TestEligibiliteManagerInterface } from "@/apps/public/services/TestElig
 const PIECES_LABELS: Record<PieceProcedure, string> = {
   [PieceProcedure.ActeIntroductif]:
     "Acte introductif de la procédure (requête, assignation, citation, déclaration d'appel, etc.)",
-  [PieceProcedure.Ecritures]: "Conclusions, mémoires ou autres écritures",
-  [PieceProcedure.Convocations]: "Convocations, avis d'audience ou notifications",
-  [PieceProcedure.Echanges]: "Courriers ou échanges avec la juridiction ou le greffe",
   [PieceProcedure.DocumentsProcedure]:
-    "Documents relatifs au déroulement de la procédure (renvois, calendrier de procédure, mise en état, etc.)",
+    "Documents relatifs au déroulement de la procédure (convocation, avis d'audience, renvois, calendrier de procédure, mise en état, etc.)",
+  [PieceProcedure.Echanges]: "Courriers ou échanges avec la juridiction ou le greffe",
+  [PieceProcedure.Ecritures]: "Conclusions, mémoires ou autres écritures",
   [PieceProcedure.Aucune]: "Je ne dispose d'aucun de ces documents",
 };
 
 const PIECES_DISPONIBLES = [
   PieceProcedure.ActeIntroductif,
-  PieceProcedure.Ecritures,
-  PieceProcedure.Convocations,
-  PieceProcedure.Echanges,
   PieceProcedure.DocumentsProcedure,
+  PieceProcedure.Echanges,
+  PieceProcedure.Ecritures,
 ];
 
 export function StepPiecesProc({ onPrecedent, onSuivant, onAnnuler, onRetour, isLastStep, test }: StepProps) {
@@ -94,7 +92,7 @@ export function StepPiecesProc({ onPrecedent, onSuivant, onAnnuler, onRetour, is
         <Alert
           className="fr-mt-2w"
           severity="error"
-          title="Démarche non éligible"
+          title="Vous n'êtes pas éligible à déposer un dossier"
           description="L'examen de la demande nécessite la production de documents permettant de retracer le déroulement de la procédure concernée."
         />
       )}

--- a/frontend/src/apps/public/components/steps/StepTypeDecision.tsx
+++ b/frontend/src/apps/public/components/steps/StepTypeDecision.tsx
@@ -15,7 +15,7 @@ const TYPE_DECISION_LABELS: Record<TypeDecision, string> = {
   [TypeDecision.JugementPremiereInstance]: "Décision de première instance",
   [TypeDecision.ArretCourAppel]: "Décision de la cour d'appel",
   [TypeDecision.ArretCourCassation]: "Décision de la Cour de cassation",
-  [TypeDecision.Aucune]: "Je ne dispose pas de la décision",
+  [TypeDecision.Aucune]: "Je ne dispose d'aucune décision",
 };
 
 const DECISIONS_DISPONIBLES = [
@@ -88,8 +88,7 @@ export function StepTypeDecision({ onPrecedent, onSuivant, onAnnuler, onRetour, 
         <Alert
           className="fr-mt-2w"
           severity="error"
-          title="La décision de justice est requise"
-          description="La décision de justice concernée est nécessaire à l'examen de votre demande. Nous vous invitons à vous en munir avant de poursuivre votre démarche."
+          title="Il est nécessaire de disposer d'une décision de justice"
         />
       )}
       <formulaire.Subscribe

--- a/frontend/src/apps/public/components/types.ts
+++ b/frontend/src/apps/public/components/types.ts
@@ -15,7 +15,6 @@ export type TypeDecision = (typeof TypeDecision)[keyof typeof TypeDecision];
 export const PieceProcedure = {
   ActeIntroductif: "acte_introductif",
   Ecritures: "ecritures",
-  Convocations: "convocations",
   Echanges: "echanges",
   DocumentsProcedure: "documents_procedure",
   Aucune: "aucune",

--- a/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/1-date-decision.tsx
+++ b/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/1-date-decision.tsx
@@ -24,7 +24,7 @@ function DateDecisionRoute() {
         homeLinkProps={{ href: "/" }}
         segments={[
           {
-            label: "Déclarer un déni de justice",
+            label: "Déclarer un délai déraisonnable de procédure",
             linkProps: { to: "/dysfonctionnement/tester-mon-eligibilite/" },
           },
         ]}

--- a/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/2-action-contentieuse.tsx
+++ b/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/2-action-contentieuse.tsx
@@ -24,7 +24,7 @@ function ActionContentieuseRoute() {
         homeLinkProps={{ href: "/" }}
         segments={[
           {
-            label: "Déclarer un déni de justice",
+            label: "Déclarer un délai déraisonnable de procédure",
             linkProps: { to: "/dysfonctionnement/tester-mon-eligibilite/" },
           },
         ]}

--- a/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/3-type-decision.tsx
+++ b/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/3-type-decision.tsx
@@ -24,7 +24,7 @@ function TypeDecisionRoute() {
         homeLinkProps={{ href: "/" }}
         segments={[
           {
-            label: "Déclarer un déni de justice",
+            label: "Déclarer un délai déraisonnable de procédure",
             linkProps: { to: "/dysfonctionnement/tester-mon-eligibilite/" },
           },
         ]}

--- a/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/4-pieces-procedure.tsx
+++ b/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/4-pieces-procedure.tsx
@@ -24,7 +24,7 @@ function PiecesProcedureRoute() {
         homeLinkProps={{ href: "/" }}
         segments={[
           {
-            label: "Déclarer un déni de justice",
+            label: "Déclarer un délai déraisonnable de procédure",
             linkProps: { to: "/dysfonctionnement/tester-mon-eligibilite/" },
           },
         ]}

--- a/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/5-diligences.tsx
+++ b/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/5-diligences.tsx
@@ -23,7 +23,7 @@ function DiligencesRoute() {
         homeLinkProps={{ href: "/" }}
         segments={[
           {
-            label: "Déclarer un déni de justice",
+            label: "Déclarer un délai déraisonnable de procédure",
             linkProps: { to: "/dysfonctionnement/tester-mon-eligibilite/" },
           },
         ]}

--- a/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/index.tsx
+++ b/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/index.tsx
@@ -11,12 +11,12 @@ function AccueilVisiteur() {
   return (
     <Layout>
       <Breadcrumb
-        currentPageLabel="Déclarer un déni de justice"
+        currentPageLabel="Déclarer un délai déraisonnable de procédure"
         homeLinkProps={{ href: "/" }}
         segments={[]}
       />
 
-      <h1>Déclarer un déni de justice</h1>
+      <h1>Déclarer un délai déraisonnable de procédure</h1>
 
       <p className="fr-mb-3w">
        Ce service vous permet de déclarer une situation susceptible de constituer un déni de justice en raison
@@ -27,7 +27,7 @@ function AccueilVisiteur() {
 
       <CallOut
         iconId="fr-icon-information-line"
-        title="Liste des documents demandés pour une déclaration de déni de justice"
+        title="Liste des documents demandés pour une déclaration de délai déraisonnable de procédure"
         bodyAs="div"
       >
         <p>
@@ -38,8 +38,8 @@ function AccueilVisiteur() {
         </p>
 
         <p>
-          Documents et informations à fournir pour une déclaration de déni
-          de justice :
+          Documents et informations à fournir pour une déclaration d'un
+          délai déraisonnable de procédure :
         </p>
         <ul>
           <li>Pièce d'identité en cours de validité</li>

--- a/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/resultat.tsx
+++ b/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/resultat.tsx
@@ -23,7 +23,7 @@ function ResultatEligibiliteRoute() {
         homeLinkProps={{ href: "/" }}
         segments={[
           {
-            label: "Déclarer un déni de justice",
+            label: "Déclarer un délai déraisonnable de procédure",
             linkProps: { to: "/dysfonctionnement/tester-mon-eligibilite/" },
           },
         ]}
@@ -41,7 +41,6 @@ function ResultatEligibiliteRoute() {
       </div>
 
       <h1>Résultat du test d'éligibilité</h1>
-      <p className="fr-mb-3w">Synthèse de vos réponses et éligibilité préliminaire.</p>
 
       <div
         className="fr-mb-3w"
@@ -83,10 +82,10 @@ function ResultatEligibiliteRoute() {
         <Alert
           className="fr-mb-3w"
           severity={eligible ? "success" : "error"}
-          title={eligible ? "Demande éligible" : "Demande non éligible en l'état"}
+          title={eligible ? "Vous pouvez déposer votre dossier" : "Demande non éligible en l'état"}
           description={
             eligible
-              ? "Votre demande semble recevable. Constituez votre dossier."
+              ? undefined
               : "Un ou plusieurs critères ne sont pas remplis. Consultez le détail ci-dessus."
           }
         />

--- a/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/test-eligibilite.tsx
+++ b/frontend/src/apps/public/routes/dysfonctionnement/tester-mon-eligibilite/test-eligibilite.tsx
@@ -30,7 +30,7 @@ function TestEligibiliteRoute() {
         homeLinkProps={{ href: "/" }}
         segments={[
           {
-            label: "Déclarer un déni de justice",
+            label: "Déclarer un délai déraisonnable de procédure",
             linkProps: { to: "/dysfonctionnement/tester-mon-eligibilite/" },
           },
         ]}
@@ -39,7 +39,7 @@ function TestEligibiliteRoute() {
       <h1>Test d'éligibilité</h1>
 
       <p className="fr-mb-3w">
-       Ce test vous permet de vérifier si votre situation est susceptible de relever d’un déni de justice et de faire l’objet d’une demande de réparation.
+       Ce test vous permet de vérifier si votre situation est susceptible de relever d’un délai déraisonnable de procédure et de faire l’objet d’une demande de réparation.
        Répondez aux questions suivantes pour poursuivre votre démarche. 
       </p>
 
@@ -48,12 +48,12 @@ function TestEligibiliteRoute() {
           <Alert
             className="fr-mb-3w"
             severity="error"
-            title="Vous ne pouvez pas poursuivre le test d’éligibilité."
+            title="Vous n’êtes pas éligible à déposer un dossier."
             description={
               <>
                 <p>La procédure concernée par votre demande est toujours en cours.</p>
                 <p>
-                  Une demande de réparation au titre d’un déni de justice ne peut être déposée qu’après que la juridiction concernée a statué.
+                  Une demande de réparation au titre d’un délai déraisonnable de procédure ne peut être déposée qu’après que la juridiction concernée a statué.
                 </p>
                 <p>
                   Vous pourrez renouveler votre démarche une fois la décision rendue.

--- a/frontend/src/apps/public/services/eligibiliteStore.ts
+++ b/frontend/src/apps/public/services/eligibiliteStore.ts
@@ -75,7 +75,7 @@ export function critereDiligences(preuves: boolean): CritereEligibilite {
   return {
     label: "Diligences accomplies",
     rempli: preuves,
-    detail: preuves ? "Oui, j'ai des preuves" : "Non, je n'ai pas de preuves",
+    detail: preuves ? "Oui, j'ai des preuves des démarches" : "Non, je n'ai pas de preuves",
   };
 }
 

--- a/frontend/tests/apps/public/components/formulaires/eligibilite.schemas.test.ts
+++ b/frontend/tests/apps/public/components/formulaires/eligibilite.schemas.test.ts
@@ -87,7 +87,7 @@ describe("SchemaEtapePiecesProc", () => {
   it("accepte plusieurs pièces", () => {
     expect(
       SchemaEtapePiecesProc.safeParse({
-        piecesProc: ["acte_introductif", "ecritures", "convocations"],
+        piecesProc: ["acte_introductif", "ecritures", "documents_procedure"],
       }).success,
     ).toBe(true);
   });


### PR DESCRIPTION
**Réviser les libellés du tunnel de test d'éligibilité dysfonctionnement**

Aligne les textes sur la dernière relecture (suppression des dernières occurrences de "déni de justice", messages de blocage uniformisés en "Vous n'êtes pas éligible à déposer un dossier"), remonte le calcul de prescription au-dessus du rappel légal à l'étape date de décision, et fusionne les pièces de procédure "convocations"/"documents-procedure"
en une seule option.
