### PR TITLE
La personne physique peut être null

### DIFF
--- a/backend/src/Api/Requerant/Dossier/Dto/DossierDto.php
+++ b/backend/src/Api/Requerant/Dossier/Dto/DossierDto.php
@@ -44,7 +44,7 @@ class DossierDto
             ->setRequerant(
                 $this->estPersonneMorale ?
                     $this->personneMorale?->versPersonneMorale($dossier?->getRequerantPersonneMorale()) :
-                    $this->personnePhysique->versPersonnePhysique($dossier?->getRequerantPersonnePhysique())
+                    $this->personnePhysique?->versPersonnePhysique($dossier?->getRequerantPersonnePhysique())
             )
             ->setBrisPorte(
                 $dossier->getBrisPorte()

--- a/backend/src/Entity/Dossier.php
+++ b/backend/src/Entity/Dossier.php
@@ -165,12 +165,14 @@ class Dossier
         return $this->getRequerantPersonne()->getCourriel();
     }
 
-    public function setRequerant(PersonnePhysique|PersonneMorale $requerant): self
+    public function setRequerant(null|PersonnePhysique|PersonneMorale $requerant): self
     {
-        if ($requerant instanceof PersonneMorale) {
-            $this->requerantPersonneMorale = $requerant;
-        } else {
-            $this->requerantPersonnePhysique = $requerant;
+        if (null !== $requerant) {
+            if ($requerant instanceof PersonneMorale) {
+                $this->requerantPersonneMorale = $requerant;
+            } else {
+                $this->requerantPersonnePhysique = $requerant;
+            }
         }
 
         return $this;


### PR DESCRIPTION
# Erreur Sentry : personne physique null

cf. [cette erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/308984/) : il peut arriver que sur un dossier en cours de constitution il n'y ait pas encore de personne physique